### PR TITLE
Changed github access protocol in ip_list.yml

### DIFF
--- a/ips_list.yml
+++ b/ips_list.yml
@@ -20,6 +20,6 @@
 
 pulp_soc:
   commit: master
-  server: git@github.com
+  server: https://github.com
   group:  pulp-platform
 


### PR DESCRIPTION
update-ips script fails when no ssh key is setup for auth on the system. Using https would be better. 