### PR TITLE
Added -64 to vopt.

### DIFF
--- a/sim/tcl_files/rtl_vopt.tcl
+++ b/sim/tcl_files/rtl_vopt.tcl
@@ -25,8 +25,8 @@ set VSIM_RTL_LIBS [regsub -all -- "-L " $VSIM_RTL_LIBS $sub_str]
 
 if {[info exists ::env(VSIM_PATH)]} {
     #eval exec >@stdout vopt +acc=mnpr -o vopt_tb tb_pulp -floatparameters+tb_pulp -Ldir $::env(VSIM_PATH)/modelsim_libs $VSIM_IP_LIBS $VSIM_RTL_LIBS -work work  
-    eval exec >@stdout vopt +acc=mnpr -o vopt_tb tb_pulp -floatparameters+tb_pulp  $VSIM_IP_LIBS $VSIM_RTL_LIBS -work work 
+    eval exec >@stdout vopt -64 +acc=mnpr -o vopt_tb tb_pulp -floatparameters+tb_pulp  $VSIM_IP_LIBS $VSIM_RTL_LIBS -work work 
 } else {
-    eval exec >@stdout vopt +acc=mnpr -o vopt_pulp_chip pulp_chip $VSIM_IP_LIBS $VSIM_RTL_LIBS -work pulpissimo_lib
+    eval exec >@stdout vopt -64 +acc=mnpr -o vopt_pulp_chip pulp_chip $VSIM_IP_LIBS $VSIM_RTL_LIBS -work pulpissimo_lib
 }
 


### PR DESCRIPTION
Added -64 to vopt in sim/tcl_files/rtl_vopt.tcl since vsim runs per default in 64bit mode in is not able to execute 32bit binaries (vopt_tb)