### PR TITLE
Fix README commands for installing SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ git clone https://github.com/pulp-platform/pulp-builder.git
 cd pulp-builder
 source configs/pulpissimo_v2.sh
 ./scripts/clean
-./scripts/build-runtime
 source sdk-setup.sh
+./scripts/build-runtime
 source configs/rtl.sh
 cd ..
 ```


### PR DESCRIPTION
Hi @haugoug 

When strictly following the commands in README.md for installing the SDK (scripts/build-sdk), I got the following error : 

```
install -D include/rt/data/rt_data_bridge.h /include/rt/data/rt_data_bridge.h
plpflags gen  --output-dir=/home/maxhonneux/PULP/pulp-builder/build/pulp-rt/pulpissimo --makefile=/home/maxhonneux/PULP/pulp-builder/build/pulp-rt/pulpissimo/config.mk  --property=fc/archi  --property=pe/archi  --property=pulp_chip  --property=pulp_chip_family  --property=soc/cluster  --property=host/archi  --property=fc_itc  --property=udma/hyper  --property=udma  --property=udma/cpi  --property=udma/i2c/version  --property=soc/fll  --property=udma/i2s/version  --property=udma/uart  --property=event_unit/version  --property=perf_counters  --property=fll/version  --property=soc/spi_master  --property=soc/apb_uart  --property=padframe/version  --property=udma/spim  --property=udma/spim/version  --property=gpio/version  --property=rtc  --property=udma/archi  --property=soc_eu/version  --property=compiler  --property=rtc/version  --lib=rt  --lib=omp  --lib=rtio  --lib=bench
install: cannot create directory /include: Permission denied
make: *** [/include/rt/data/rt_data_bridge.h] Error 1
make: *** Waiting for unfinished jobs....
```

Seems that an envvar was missing (PULP_SDK_WS_INSTALL). Sourcing sdk-setup.sh before building the SDK fixed this.

I don't know if there's a better way to handle this issue, if not this PR could help future users.