### PR TITLE
Reenable pulp tap

### DIFF
--- a/rtl/tb/dbg_pkg.sv
+++ b/rtl/tb/dbg_pkg.sv
@@ -453,9 +453,9 @@ package dbg_pkg;
       );
          logic [255:0] dataout;
          jtag_soc_dbg.start_shift(s_tck, s_tms, s_trstn, s_tdi);
-         jtag_soc_dbg.shift_nbits(6, DBG_MODULE, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
+         jtag_soc_dbg.shift_nbits(6+1, {1'b0, DBG_MODULE}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
          jtag_soc_dbg.update_and_goto_shift(s_tck, s_tms, s_trstn, s_tdi);
-         jtag_soc_dbg.shift_nbits(53,{DBG_WRITE8, addr, nwords[15:0]}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
+         jtag_soc_dbg.shift_nbits(53+1,{1'b0, DBG_WRITE8, addr, nwords[15:0]}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
          jtag_soc_dbg.update_and_goto_shift(s_tck, s_tms, s_trstn, s_tdi);
          jtag_soc_dbg.shift_nbits_noex(9, {data[0], 1'b1}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
          for(int i=1; i<nwords; i++)
@@ -477,9 +477,9 @@ package dbg_pkg;
       );
          logic [255:0] dataout;
          jtag_soc_dbg.start_shift(s_tck, s_tms, s_trstn, s_tdi);
-         jtag_soc_dbg.shift_nbits(6, DBG_MODULE, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
+         jtag_soc_dbg.shift_nbits(6+1, {1'b0, DBG_MODULE}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
          jtag_soc_dbg.update_and_goto_shift(s_tck, s_tms, s_trstn, s_tdi);
-         jtag_soc_dbg.shift_nbits(53,{DBG_WRITE16, addr, nwords[15:0]}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
+         jtag_soc_dbg.shift_nbits(53+1,{1'b0, DBG_WRITE16, addr, nwords[15:0]}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
          jtag_soc_dbg.update_and_goto_shift(s_tck, s_tms, s_trstn, s_tdi);
          jtag_soc_dbg.shift_nbits_noex(17, {data[0], 1'b1}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
          for(int i=1; i<nwords; i++)
@@ -500,15 +500,16 @@ package dbg_pkg;
          ref logic s_tdo
       );
          logic [255:0] dataout;
+
          jtag_soc_dbg.start_shift(s_tck, s_tms, s_trstn, s_tdi);
          jtag_soc_dbg.shift_nbits(6+1, {1'b0, DBG_MODULE}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
          jtag_soc_dbg.update_and_goto_shift(s_tck, s_tms, s_trstn, s_tdi);
          jtag_soc_dbg.shift_nbits(53+1,{1'b0, DBG_WRITE32, addr, nwords[15:0]}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
          jtag_soc_dbg.update_and_goto_shift(s_tck, s_tms, s_trstn, s_tdi);
-         jtag_soc_dbg.shift_nbits_noex(33+1, {1'b0, data[0], 1'b1}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
+         jtag_soc_dbg.shift_nbits_noex(33, {data[0], 1'b1}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
          for(int i=1; i<nwords; i++)
-            jtag_soc_dbg.shift_nbits_noex(32+1, {1'b0,data[i]}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
-         jtag_soc_dbg.shift_nbits(34+1, {2'b0, 32'h11111111}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo); // for now we completely ignore CRC
+            jtag_soc_dbg.shift_nbits_noex(32, data[i], dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
+         jtag_soc_dbg.shift_nbits(34, {2'b0, 32'h11111111}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo); // for now we completely ignore CRC
          jtag_soc_dbg.idle(s_tck, s_tms, s_trstn, s_tdi);
          $display("[dbg_if_soc] WRITE32 burst @%h for %d bytes.", addr, nwords*4);
       endtask
@@ -525,9 +526,9 @@ package dbg_pkg;
       );
          logic [255:0] dataout;
          jtag_soc_dbg.start_shift(s_tck, s_tms, s_trstn, s_tdi);
-         jtag_soc_dbg.shift_nbits(6, DBG_MODULE, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
+         jtag_soc_dbg.shift_nbits(6+1, {1'b0, DBG_MODULE}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
          jtag_soc_dbg.update_and_goto_shift(s_tck, s_tms, s_trstn, s_tdi);
-         jtag_soc_dbg.shift_nbits(53,{DBG_WRITE64, addr, nwords[15:0]}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
+         jtag_soc_dbg.shift_nbits(53,{1'b0, DBG_WRITE64, addr, nwords[15:0]}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
          jtag_soc_dbg.update_and_goto_shift(s_tck, s_tms, s_trstn, s_tdi);
          jtag_soc_dbg.shift_nbits_noex(65, {data[0], 1'b1}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
          for(int i=1; i<nwords; i++)
@@ -558,13 +559,13 @@ package dbg_pkg;
            jtag_soc_dbg.shift_nbits_noex(1, 1'b0, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
            if(dataout[0] == 1'b1) break;
          end
-         jtag_soc_dbg.shift_nbits_noex(8+1, {1'b0,8'b0}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
+         jtag_soc_dbg.shift_nbits_noex(8, 8'b0, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
          data[0] = dataout[7:0];
          for(int i=1; i<nwords; i++) begin
-            jtag_soc_dbg.shift_nbits_noex(8+1, {1'b0,8'b0}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
+            jtag_soc_dbg.shift_nbits_noex(8, 8'b0, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
             data[i] = dataout[7:0];
          end
-         jtag_soc_dbg.shift_nbits(34+1, {1'b0, 2'b0, 32'b0}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo); // for now we completely ignore CRC
+         jtag_soc_dbg.shift_nbits(34, {2'b0, 32'b0}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo); // for now we completely ignore CRC
          jtag_soc_dbg.idle(s_tck, s_tms, s_trstn, s_tdi);
          $display("[dbg_if_soc] READ8 burst @%h for %d bytes.", addr, nwords);
       endtask
@@ -581,9 +582,9 @@ package dbg_pkg;
       );
          logic [255:0] dataout;
          jtag_soc_dbg.start_shift(s_tck, s_tms, s_trstn, s_tdi);
-         jtag_soc_dbg.shift_nbits(6, DBG_MODULE, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
+         jtag_soc_dbg.shift_nbits(6+1, {1'b0, DBG_MODULE}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
          jtag_soc_dbg.update_and_goto_shift(s_tck, s_tms, s_trstn, s_tdi);
-         jtag_soc_dbg.shift_nbits(53,{DBG_READ16, addr, nwords[15:0]}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
+         jtag_soc_dbg.shift_nbits(53+1,{1'b0, DBG_READ16, addr, nwords[15:0]}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
          jtag_soc_dbg.update_and_goto_shift(s_tck, s_tms, s_trstn, s_tdi);
          while(1) // wait for a '1' from the AXI module
          begin
@@ -622,13 +623,13 @@ package dbg_pkg;
            jtag_soc_dbg.shift_nbits_noex(1, 1'b0, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
            if(dataout[0] == 1'b1) break;
          end
-         jtag_soc_dbg.shift_nbits_noex(32+1, 33'b0, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
+         jtag_soc_dbg.shift_nbits_noex(32, 32'b0, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
          data[0] = dataout[31:0];
          for(int i=1; i<nwords; i++) begin
-            jtag_soc_dbg.shift_nbits_noex(32+1,{1'b0,32'b0}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
+            jtag_soc_dbg.shift_nbits_noex(32,{32'b0}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
             data[i] = dataout[31:0];
          end
-         jtag_soc_dbg.shift_nbits(34+1, {1'b0, 2'b0, 32'b0}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo); // for now we completely ignore CRC
+         jtag_soc_dbg.shift_nbits(34, {2'b0, 32'b0}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo); // for now we completely ignore CRC
          jtag_soc_dbg.idle(s_tck, s_tms, s_trstn, s_tdi);
          // $display("[dbg_if_soc] READ32 burst @%h for %d bytes.", addr, nwords*4);
       endtask
@@ -645,9 +646,9 @@ package dbg_pkg;
       );
          logic [255:0] dataout;
          jtag_soc_dbg.start_shift(s_tck, s_tms, s_trstn, s_tdi);
-         jtag_soc_dbg.shift_nbits(6, DBG_MODULE, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
+         jtag_soc_dbg.shift_nbits(6+1, {1'b0, DBG_MODULE}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
          jtag_soc_dbg.update_and_goto_shift(s_tck, s_tms, s_trstn, s_tdi);
-         jtag_soc_dbg.shift_nbits(53,{DBG_READ64, addr, nwords[15:0]}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
+         jtag_soc_dbg.shift_nbits(53+1,{1'b0, DBG_READ64, addr, nwords[15:0]}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
          jtag_soc_dbg.update_and_goto_shift(s_tck, s_tms, s_trstn, s_tdi);
          while(1) // wait for a '1' from the AXI module
          begin
@@ -699,7 +700,7 @@ package dbg_pkg;
      dbg_if.cpu_write(cpu_id, {16'b0, 6'b1, 5'b0, addr}, 1, tmp, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
    endtask
 
-   task automatic jtag_load_L2(
+   task automatic load_L2(
       input int          num_stim,
       ref   logic [95:0] stimuli [100000:0],
       ref logic s_tck,
@@ -751,6 +752,6 @@ package dbg_pkg;
 
       end
 
-   endtask : jtag_load_L2
+   endtask : load_L2
 
 endpackage

--- a/rtl/tb/jtag_pkg.sv
+++ b/rtl/tb/jtag_pkg.sv
@@ -452,6 +452,19 @@ package jtag_pkg;
          ref logic s_tck,
          ref logic s_tms,
          ref logic s_trstn,
+         ref logic s_tdi
+      );
+
+         JTAG_reg #(.size(32+1), .instr({JTAG_SOC_DTMCSR, JTAG_SOC_BYPASS})) jtag_soc_dbg = new;
+         jtag_soc_dbg.setIR(s_tck, s_tms, s_trstn, s_tdi);
+
+      endtask
+
+
+      task init_long(
+         ref logic s_tck,
+         ref logic s_tms,
+         ref logic s_trstn,
          ref logic s_tdi,
          ref logic s_tdo
       );

--- a/rtl/tb/pulp_tap_pkg.sv
+++ b/rtl/tb/pulp_tap_pkg.sv
@@ -9,15 +9,16 @@
 // specific language governing permissions and limitations under the License.
 
 /*
- * dbg_pkg.sv
+ * pulp_tap_pkg.sv
  * Francesco Conti <fconti@iis.ee.ethz.ch>
  * Antonio Pullini <pullinia@iis.ee.ethz.ch>
+ * Robert Balas <balasr@iis.ee.ethz.ch>
  */
 
-package dbg_pkg;
+package pulp_tap_pkg;
 
    parameter logic [7:0] DBG_MODULE     = 6'b100000;
-   parameter logic [7:0] DBG_CPU_MODULE = 6'b100001;
+   // parameter logic [7:0] DBG_CPU_MODULE = 6'b100001;
 
    parameter logic [6:0] DBG_NOP     = 5'h0;
    parameter logic [6:0] DBG_WRITE8  = 5'h1;
@@ -31,15 +32,15 @@ package dbg_pkg;
    parameter logic [6:0] DBG_WREG    = 5'h9;
    parameter logic [6:0] DBG_SELREG  = 5'hD;
 
-   parameter logic [6:0] DBG_CPU_NOP    = 5'h0;
-   parameter logic [6:0] DBG_CPU_WRITE  = 5'h3;
-   parameter logic [6:0] DBG_CPU_READ   = 5'h7;
-   parameter logic [6:0] DBG_CPU_WREG   = 5'h9;
-   parameter logic [6:0] DBG_CPU_SELREG = 5'hD;
+   // parameter logic [6:0] DBG_CPU_NOP    = 5'h0;
+   // parameter logic [6:0] DBG_CPU_WRITE  = 5'h3;
+   // parameter logic [6:0] DBG_CPU_READ   = 5'h7;
+   // parameter logic [6:0] DBG_CPU_WREG   = 5'h9;
+   // parameter logic [6:0] DBG_CPU_SELREG = 5'hD;
 
-   parameter logic [3:0] DBG_CPU_REG_STATUS = 3'b000;
+   // parameter logic [3:0] DBG_CPU_REG_STATUS = 3'b000;
 
-   class dbg_if_cluster_t;
+   class pulp_tap_if_cluster_t;
 
       jtag_pkg::JTAG_reg #(.size(256), .instr({jtag_pkg::JTAG_SOC_BYPASS, jtag_pkg::JTAG_CLUSTER_DEBUG})) jtag_cluster_dbg;
 
@@ -264,7 +265,7 @@ package dbg_pkg;
          //$display("[dbg_if] READ32 burst @%h for %d bytes.", addr, nwords*4);
       endtask
 
-      task read64(
+    task read64(
          input  logic[31:0]         addr,
          input  int                 nwords,
          output logic [255:0][63:0] data,
@@ -296,120 +297,9 @@ package dbg_pkg;
          //$display("[dbg_if] READ64 burst @%h for %d bytes.", addr, nwords*8);
       endtask
 
-      task cpu_write(
-         input logic [3:0]         cpu_id,
-         input logic[31:0]         addr,
-         input int                 nwords,
-         input logic [255:0][31:0] data,
-         ref logic s_tck,
-         ref logic s_tms,
-         ref logic s_trstn,
-         ref logic s_tdi,
-         ref logic s_tdo
-      );
-         logic [255:0] dataout;
-         jtag_cluster_dbg.start_shift(s_tck, s_tms, s_trstn, s_tdi);
-         jtag_cluster_dbg.shift_nbits(7, {1'b0, DBG_CPU_MODULE}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
-         jtag_cluster_dbg.update_and_goto_shift(s_tck, s_tms, s_trstn, s_tdi);
-         jtag_cluster_dbg.shift_nbits(58,{1'b0, DBG_CPU_WRITE, cpu_id, addr, nwords[15:0]}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
-         jtag_cluster_dbg.update_and_goto_shift(s_tck, s_tms, s_trstn, s_tdi);
-         jtag_cluster_dbg.shift_nbits_noex(33, {data[0], 1'b1}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
-         for(int i=1; i<nwords; i++)
-            jtag_cluster_dbg.shift_nbits_noex(32, data[i], dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
-         jtag_cluster_dbg.shift_nbits(34, {2'b0, 32'h11111111}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo); // for now we completely ignore C, s_tdoRC
-         jtag_cluster_dbg.idle(s_tck, s_tms, s_trstn, s_tdi);
-         $display("[dbg_if] CPU WRITE burst @%h for %d bytes.", addr, nwords*4);
-      endtask
-
-      task cpu_read(
-         input  logic [3:0]         cpu_id,
-         input  logic[31:0]         addr,
-         input  int                 nwords,
-         output logic [255:0][31:0] data,
-         ref logic s_tck,
-         ref logic s_tms,
-         ref logic s_trstn,
-         ref logic s_tdi,
-         ref logic s_tdo
-      );
-         logic [255:0] dataout;
-         jtag_cluster_dbg.start_shift(s_tck, s_tms, s_trstn, s_tdi);
-         jtag_cluster_dbg.shift_nbits(7, {1'b0, DBG_CPU_MODULE}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
-         jtag_cluster_dbg.update_and_goto_shift(s_tck, s_tms, s_trstn, s_tdi);
-         jtag_cluster_dbg.shift_nbits(58,{1'b0, DBG_CPU_READ, cpu_id, addr, nwords[15:0]}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
-         jtag_cluster_dbg.update_and_goto_shift(s_tck, s_tms, s_trstn, s_tdi);
-         while(1) // wait for a '1' from the OR1K module
-         begin
-           jtag_cluster_dbg.shift_nbits_noex(1, {1'b0}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
-           if(dataout[0] == 1'b1) break;
-         end
-         jtag_cluster_dbg.shift_nbits_noex(32, 32'b0, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
-         data[0] = dataout[31:0];
-         for(int i=1; i<nwords; i++) begin
-            jtag_cluster_dbg.shift_nbits_noex(32, 32'b0, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
-            data[i] = dataout[31:0];
-         end
-         jtag_cluster_dbg.shift_nbits(34, {2'b0, 32'b0}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo); // for now we completely ignore C, s_tdoRC
-         jtag_cluster_dbg.idle(s_tck, s_tms, s_trstn, s_tdi);
-         $display("[dbg_if] CPU READ burst @%h for %d bytes.", addr, nwords*4);
-      endtask
-
-      task cpu_wait_for_stall(
-         ref logic s_tck,
-         ref logic s_tms,
-         ref logic s_trstn,
-         ref logic s_tdi,
-         ref logic s_tdo
-      );
-         logic [255:0] dataout;
-         while(1)
-         begin
-           jtag_cluster_dbg.start_shift(s_tck, s_tms, s_trstn, s_tdi);
-           jtag_cluster_dbg.shift_nbits(7, {1'b0, DBG_CPU_MODULE}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
-           jtag_cluster_dbg.update_and_goto_shift(s_tck, s_tms, s_trstn, s_tdi);
-           jtag_cluster_dbg.shift_nbits(9,{1'b0, DBG_CPU_NOP, DBG_CPU_REG_STATUS, 2'b0}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
-           jtag_cluster_dbg.idle(s_tck, s_tms, s_trstn, s_tdi);
-
-           if(dataout[0] == 1'b1) break;
-         end
-      endtask
-
-      task cpu_stall(
-         input logic [3:0] cpu_mask,
-         ref logic s_tck,
-         ref logic s_tms,
-         ref logic s_trstn,
-         ref logic s_tdi,
-         ref logic s_tdo
-      );
-         logic [255:0] dataout;
-         jtag_cluster_dbg.start_shift(s_tck, s_tms, s_trstn, s_tdi);
-         jtag_cluster_dbg.shift_nbits(7, {1'b0, DBG_CPU_MODULE}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
-         jtag_cluster_dbg.update_and_goto_shift(s_tck, s_tms, s_trstn, s_tdi);
-         jtag_cluster_dbg.shift_nbits(13,{1'b0, 1'b0, DBG_CPU_WREG, DBG_CPU_REG_STATUS, cpu_mask}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
-         jtag_cluster_dbg.idle(s_tck, s_tms, s_trstn, s_tdi);
-         $display("[dbg_if] CPU STALL command.");
-      endtask
-
-      task cpu_reset(
-         ref logic s_tck,
-         ref logic s_tms,
-         ref logic s_trstn,
-         ref logic s_tdi,
-         ref logic s_tdo
-      );
-         logic [255:0] dataout;
-         jtag_cluster_dbg.start_shift(s_tck, s_tms, s_trstn, s_tdi);
-         jtag_cluster_dbg.shift_nbits(7, {1'b0, DBG_CPU_MODULE}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
-         jtag_cluster_dbg.update_and_goto_shift(s_tck, s_tms, s_trstn, s_tdi);
-         jtag_cluster_dbg.shift_nbits(13,{1'b0, 1'b0, DBG_CPU_WREG, DBG_CPU_REG_STATUS, 4'b0000}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
-         jtag_cluster_dbg.idle(s_tck, s_tms, s_trstn, s_tdi);
-         $display("[dbg_if] CPU RESET command.");
-      endtask
-
    endclass
 
-   class dbg_if_soc_t;
+   class pulp_tap_if_soc_t;
 
       jtag_pkg::JTAG_reg #(.size(256), .instr({jtag_pkg::JTAG_SOC_BYPASS, jtag_pkg::JTAG_SOC_AXIREG})) jtag_soc_dbg;
 
@@ -438,7 +328,7 @@ package dbg_pkg;
          jtag_soc_dbg.update_and_goto_shift(s_tck, s_tms, s_trstn, s_tdi);
          jtag_soc_dbg.update_and_goto_shift(s_tck, s_tms, s_trstn, s_tdi);
          jtag_soc_dbg.idle(s_tck, s_tms, s_trstn, s_tdi);
-         $display("[dbg_if_soc] NOP command.");
+         $display("[pulp_tap_if] NOP command.");
       endtask
 
       task write8(
@@ -462,7 +352,7 @@ package dbg_pkg;
             jtag_soc_dbg.shift_nbits_noex(8, data[i], dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
          jtag_soc_dbg.shift_nbits(34, {2'b0, 32'h11111111}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo); // for now we completely ignore CRC
          jtag_soc_dbg.idle(s_tck, s_tms, s_trstn, s_tdi);
-         $display("[dbg_if_soc] WRITE8 burst @%h for %d bytes.", addr, nwords);
+         $display("[pulp_tap_if] WRITE8 burst @%h for %d bytes.", addr, nwords);
       endtask
 
       task write16(
@@ -486,7 +376,7 @@ package dbg_pkg;
             jtag_soc_dbg.shift_nbits_noex(16, data[i], dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
          jtag_soc_dbg.shift_nbits(34, {2'b0, 32'h11111111}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo); // for now we completely ignore CRC
          jtag_soc_dbg.idle(s_tck, s_tms, s_trstn, s_tdi);
-         $display("[dbg_if_soc] WRITE16 burst @%h for %d bytes.", addr, nwords*2);
+         $display("[pulp_tap_if] WRITE16 burst @%h for %d bytes.", addr, nwords*2);
       endtask
 
       task write32(
@@ -511,7 +401,7 @@ package dbg_pkg;
             jtag_soc_dbg.shift_nbits_noex(32, data[i], dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
          jtag_soc_dbg.shift_nbits(34, {2'b0, 32'h11111111}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo); // for now we completely ignore CRC
          jtag_soc_dbg.idle(s_tck, s_tms, s_trstn, s_tdi);
-         $display("[dbg_if_soc] WRITE32 burst @%h for %d bytes.", addr, nwords*4);
+         $display("[pulp_tap_if] WRITE32 burst @%h for %d bytes.", addr, nwords*4);
       endtask
 
       task write64(
@@ -535,7 +425,7 @@ package dbg_pkg;
             jtag_soc_dbg.shift_nbits_noex(64, data[i], dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
          jtag_soc_dbg.shift_nbits(34, {2'b0, 32'h11111111}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo); // for now we completely ignore CRC
          jtag_soc_dbg.idle(s_tck, s_tms, s_trstn, s_tdi);
-         $display("[dbg_if_soc] WRITE64 burst @%h for %d bytes.", addr, nwords*8);
+         $display("[pulp_tap_if] WRITE64 burst @%h for %d bytes.", addr, nwords*8);
       endtask
 
       task read8(
@@ -567,7 +457,7 @@ package dbg_pkg;
          end
          jtag_soc_dbg.shift_nbits(34, {2'b0, 32'b0}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo); // for now we completely ignore CRC
          jtag_soc_dbg.idle(s_tck, s_tms, s_trstn, s_tdi);
-         $display("[dbg_if_soc] READ8 burst @%h for %d bytes.", addr, nwords);
+         $display("[pulp_tap_if] READ8 burst @%h for %d bytes.", addr, nwords);
       endtask
 
       task read16(
@@ -599,7 +489,7 @@ package dbg_pkg;
          end
          jtag_soc_dbg.shift_nbits(34, {2'b0, 32'b0}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo); // for now we completely ignore CRC
          jtag_soc_dbg.idle(s_tck, s_tms, s_trstn, s_tdi);
-         $display("[dbg_if_soc] READ16 burst @%h for %d bytes.", addr, nwords*2);
+         $display("[pulp_tap_if] READ16 burst @%h for %d bytes.", addr, nwords*2);
       endtask
 
       task read32(
@@ -631,7 +521,7 @@ package dbg_pkg;
          end
          jtag_soc_dbg.shift_nbits(34, {2'b0, 32'b0}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo); // for now we completely ignore CRC
          jtag_soc_dbg.idle(s_tck, s_tms, s_trstn, s_tdi);
-         // $display("[dbg_if_soc] READ32 burst @%h for %d bytes.", addr, nwords*4);
+         // $display("[pulp_tap_if] READ32 burst @%h for %d bytes.", addr, nwords*4);
       endtask
 
       task read64(
@@ -663,42 +553,10 @@ package dbg_pkg;
          end
          jtag_soc_dbg.shift_nbits(34, {2'b0, 32'b0}, dataout, s_tck, s_tms, s_trstn, s_tdi, s_tdo); // for now we completely ignore CRC
          jtag_soc_dbg.idle(s_tck, s_tms, s_trstn, s_tdi);
-         $display("[dbg_if_soc] READ64 burst @%h for %d bytes.", addr, nwords*8);
+         $display("[pulp_tap_if] READ64 burst @%h for %d bytes.", addr, nwords*8);
       endtask
 
    endclass
-
-   task automatic cpu_read_gpr(
-      input  logic [3:0]  cpu_id,
-      input  logic [4:0]  addr,
-      output logic [31:0] data,
-      ref logic s_tck,
-      ref logic s_tms,
-      ref logic s_trstn,
-      ref logic s_tdi,
-      ref logic s_tdo
-   );
-      automatic dbg_if_cluster_t dbg_if = new;
-      logic [255:0][31:0] tmp;
-      dbg_if.cpu_read(cpu_id, {16'b0, 6'b1, 5'b0, addr}, 1, tmp, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
-      data = tmp[0];
-   endtask
-
-   task automatic cpu_write_gpr(
-      input logic [3:0]  cpu_id,
-      input logic [4:0]  addr,
-      input logic [31:0] data,
-      ref logic s_tck,
-      ref logic s_tms,
-      ref logic s_trstn,
-      ref logic s_tdi,
-      ref logic s_tdo
-   );
-      automatic dbg_if_cluster_t dbg_if = new;
-     logic [255:0][31:0] tmp;
-     tmp[0] = data;
-     dbg_if.cpu_write(cpu_id, {16'b0, 6'b1, 5'b0, addr}, 1, tmp, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
-   endtask
 
    task automatic load_L2(
       input int          num_stim,
@@ -715,12 +573,12 @@ package dbg_pkg;
       automatic logic [31:0] spi_addr;
       automatic logic [31:0] spi_addr_old;
       automatic logic        more_stim = 1;
-      automatic dbg_if_soc_t dbg_if_soc = new;
+      automatic pulp_tap_if_soc_t pulp_tap = new;
       spi_addr        = stimuli[num_stim][95:64]; // assign address
       jtag_data[0]    = stimuli[num_stim][63:0];  // assign data
 
       $display("[JTAG] Loading L2 with jtag interface");
-      dbg_if_soc.init(s_tck, s_tms, s_trstn, s_tdi);
+      pulp_tap.init(s_tck, s_tms, s_trstn, s_tdi);
 
       spi_addr_old = spi_addr - 32'h8;
 
@@ -748,7 +606,7 @@ package dbg_pkg;
             end
             spi_addr_old = spi_addr;
          end
-         dbg_if_soc.write32(jtag_addr, jtag_burst_len, jtag_data, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
+         pulp_tap.write32(jtag_addr, jtag_burst_len, jtag_data, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
 
       end
 

--- a/rtl/tb/src_files.yml
+++ b/rtl/tb/src_files.yml
@@ -2,7 +2,7 @@ tb:
   files: [
     riscv_pkg.sv,
     jtag_pkg.sv,
-    dbg_pkg.sv,
+    pulp_tap_pkg.sv,
     tb_clk_gen.sv,
     tb_fs_handler.sv,
     dpi_models/dpi_models.sv,

--- a/rtl/tb/tb_pulp.sv
+++ b/rtl/tb/tb_pulp.sv
@@ -111,7 +111,7 @@ module tb_pulp;
 
    jtag_pkg::test_mode_if_t   test_mode_if = new;
    jtag_pkg::debug_mode_if_t  debug_mode_if = new;
-   dbg_pkg::dbg_if_soc_t      dbg_if_soc = new;
+   pulp_tap_pkg::pulp_tap_if_soc_t pulp_tap = new;
 
    /* system wires */
    // the w_/s_ prefixes are used to mean wire/tri-type and logic-type (respectively)
@@ -661,17 +661,17 @@ module tb_pulp;
             $display("[TB] %t - Releasing hard reset", $realtime);
 
             //test if the PULP tap che write to the L2
-            dbg_if_soc.init(s_tck, s_tms, s_trstn, s_tdi);
+            pulp_tap.init(s_tck, s_tms, s_trstn, s_tdi);
 
             $display("[TB] %t - Init PULP TAP", $realtime);
 
-            dbg_if_soc.write32(BEGIN_L2_INSTR, 1, 32'hABBAABBA,
+            pulp_tap.write32(BEGIN_L2_INSTR, 1, 32'hABBAABBA,
                 s_tck, s_tms, s_trstn, s_tdi, s_tdo);
 
             $display("[TB] %t - Write32 PULP TAP", $realtime);
 
             #50us;
-            dbg_if_soc.read32(BEGIN_L2_INSTR, 1, jtag_data,
+            pulp_tap.read32(BEGIN_L2_INSTR, 1, jtag_data,
                 s_tck, s_tms, s_trstn, s_tdi, s_tdo);
 
             if(jtag_data[0] != 32'hABBAABBA)
@@ -712,7 +712,7 @@ module tb_pulp;
                $display("[TB] %t - Loading L2", $realtime);
                if (USE_PULP_BUS_ACCESS) begin
                   // use pulp tap to load binary, put debug module in bypass
-                  dbg_pkg::load_L2(num_stim, stimuli, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
+                  pulp_tap_pkg::load_L2(num_stim, stimuli, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
                   // configure for debug module dmi access again
                   debug_mode_if.init_dmi_access(s_tck, s_tms, s_trstn, s_tdi);
                   // enable sb access for subsequent readMem calls

--- a/rtl/tb/tb_pulp.sv
+++ b/rtl/tb/tb_pulp.sv
@@ -689,7 +689,7 @@ module tb_pulp;
             // from the bootrom. For jtag booting (what we are doing right now),
             // bootsel is low so the code that is being executed in said bootrom
             // is only a busy wait or wfi until the debug unit grabs control.
-            debug_mode_if.init_long(s_tck, s_tms, s_trstn, s_tdi, s_tdo);
+            debug_mode_if.init_dmi_access(s_tck, s_tms, s_trstn, s_tdi);
 
             debug_mode_if.set_dmactive(1'b1, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
 
@@ -714,7 +714,7 @@ module tb_pulp;
                   // use pulp tap to load binary, put debug module in bypass
                   dbg_pkg::load_L2(num_stim, stimuli, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
                   // configure for debug module dmi access again
-                  debug_mode_if.init_dmi(s_tck, s_tms, s_trstn, s_tdi);
+                  debug_mode_if.init_dmi_access(s_tck, s_tms, s_trstn, s_tdi);
                   // enable sb access for subsequent readMem calls
                   debug_mode_if.set_sbreadonaddr(1'b1, s_tck, s_tms, s_trstn, s_tdi, s_tdo);
                end else begin

--- a/rtl/tb/tb_pulp.sv
+++ b/rtl/tb/tb_pulp.sv
@@ -599,7 +599,6 @@ module tb_pulp;
          logic        error;
          automatic logic [9:0]  FC_CORE_ID = {5'd31,5'd0};
 
-         force tb_pulp.i_dut.pad_frame_i.padinst_reset_n.O = 1'b0;
          if (ENABLE_EXTERNAL_DRIVER == 0 && ENABLE_OPENOCD == 0) begin
 
             // force fetch enable to 0 when doing JTAG preload (not particularly
@@ -630,7 +629,6 @@ module tb_pulp;
 
          #1ns
 
-         release tb_pulp.i_dut.pad_frame_i.padinst_reset_n.O;
          uart_tb_rx_en   = 1'b1; // enable uart rx in testbench
 
          if (ENABLE_EXTERNAL_DRIVER == 0 && ENABLE_OPENOCD == 0) begin


### PR DESCRIPTION
This patch re-enables loading binaries over the pulp tap, which is currently much faster than using the system bus access method of the debug module. `USE_PULP_BUS_ACCESS ` controls this behaviour and is enabled by default.

Furthermore some tasks were renamed to reflect the current capabilities more closely. All stuff related to the pulp tap is now called pulp_tap* instead of dbg_*.

The workaround of setting the reset pad with force/release is removed.