### PR TITLE
Fix sim targets

### DIFF
--- a/sim/Makefile
+++ b/sim/Makefile
@@ -1,13 +1,30 @@
-.PHONY: build lib clean
+.PHONY: build lib clean sim simc
 
 mkfile_path := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 
+VSIM        ?= vsim
+VSIM_FLAGS  = -gUSE_SDVT_SPI=0 -gUSE_SDVT_CPI=0 -gBAUDRATE=115200 \
+		-gENABLE_DEV_DPI=0 -gLOAD_L2=JTAG -gUSE_SDVT_I2S=0
+
+SVLIB	    =  ../rtl/tb/remote_bitbang/librbs
+
 all: clean lib build opt
+
 sim:
-	vsim -lib modelsim_libs/work vopt_tb -do "set StdArithNoWarnings 1; set NumericStdNoWarnings 1" +UVM_NO_RELNOTES
+	$(VSIM) -64 -gui vopt_tb -L models_lib -L vip_lib \
+		-suppress vsim-3009 -suppress vsim-8683 \
+		+UVM_NO_RELNOTES -stats -t ps \
+		-sv_lib $(SVLIB) $(VSIM_FLAGS) \
+		-do "set StdArithNoWarnings 1; set NumericStdNoWarnings 1"
 
 simc:
-	vsim -c -lib modelsim_libs/work vopt_tb -c -suppress vsim-3009 -suppress vsim-8683 -do "set StdArithNoWarnings 1; set NumericStdNoWarnings 1" +UVM_NO_RELNOTES
+	$(VSIM) -64 -c vopt_tb -L models_lib -L vip_lib \
+		-suppress vsim-3009 -suppress vsim-8683 \
+		+UVM_NO_RELNOTES -stats -t ps \
+		-sv_lib $(SVLIB) $(VSIM_FLAGS) \
+		-do "set StdArithNoWarnings 1; set NumericStdNoWarnings 1" \
+		-do "run -all" \
+		-do "quit -code [examine -radix decimal sim:/tb_pulp/exit_status]"
 
 opt:
 	$(mkfile_path)/tcl_files/rtl_vopt.tcl
@@ -23,4 +40,3 @@ lib:
 clean:
 	@make --no-print-directory -f $(mkfile_path)/vcompile/ips.mk clean
 	@make --no-print-directory -f $(mkfile_path)/vcompile/rtl.mk clean
-


### PR DESCRIPTION
Normally we don't use this target since running programs and calling
vsim is handled by the sdk. This fixes the case where one still wants to
manually open vsim.