### PR TITLE
Allow user to specify path to stimuli file

### DIFF
--- a/rtl/tb/tb_pulp.sv
+++ b/rtl/tb/tb_pulp.sv
@@ -93,6 +93,9 @@ module tb_pulp;
    parameter logic[1:0] JTAG_DPI    = 2'b01;
    parameter logic[1:0] JTAG_BRIDGE = 2'b10;
 
+   // contains the program code
+   string stimuli_file;
+
    /* simulation variables & flags */
    logic                 uart_tb_rx_en = 1'b0;
    logic                 uart_vip_rx_en = 1'b0;
@@ -639,9 +642,14 @@ module tb_pulp;
                else
                   $display("[TB] %t - Not using CAM SDVT", $realtime);
 
-
                // read in the stimuli vectors  == address_value
-               $readmemh("./vectors/stim.txt", stimuli);
+               if ($value$plusargs("stimuli=%s", stimuli_file)) begin
+                  $display("Loading custom stimuli from %s", stimuli_file);
+                  $readmemh(stimuli_file, stimuli);
+               end else begin
+                  $display("Loading default stimuli");
+                  $readmemh("./vectors/stim.txt", stimuli);
+               end
 
                // before starting the actual boot procedure we do some light
                // testing on the jtag link


### PR DESCRIPTION
Sometimes we want to directly load a stimuli file from a compiled
program without using the pulp-sdk directly.

Pass `+stimuli=path_to_stimuli_file` to the simulator to specify such a
stimuli file.