### PR TITLE
Add build and simulate flow for xcelium/ncsim

### DIFF
--- a/generate-scripts
+++ b/generate-scripts
@@ -5,6 +5,7 @@
 # All rights reserved.
 
 from ipstools_cfg import *
+import fileinput
 
 execute("mkdir -p sim/vcompile/ips")
 execute("rm -rf sim/vcompile/ips/*")
@@ -27,6 +28,22 @@ ipdb.generate_vsim_tcl("sim/tcl_files/config/vsim_rtl.tcl", source='rtl')
 # generate script to compile all IPs for ModelSim/QuestaSim
 ipdb.generate_makefile("sim/vcompile/ips.mk")
 ipdb.generate_makefile("sim/vcompile/rtl.mk", source='rtl')
+
+# generate XCELIUM compilation scripts
+ipdb.export_make(script_path="sim/ncompile/ips", simulator='ncsim')
+ipdb.export_make(script_path="sim/ncompile/rtl", simulator='ncsim', source='rtl')
+ipdb.generate_makefile("sim/ncompile/ips.mk")
+ipdb.generate_makefile("sim/ncompile/rtl.mk", source='rtl')
+ipdb.generate_ncsim_command_list(script_path="./sim/ncompile/src_ips_files.f",
+                                 root='.', source='ips')
+ipdb.generate_ncsim_command_list(script_path="./sim/ncompile/src_rtl_files.f",
+                                 root='.', source='rtl')
+# small hack to remove bad tb files until changes propagate
+# this is sed -i '/tb\/tb_hwpe/d' sim/ncompile/src_ips_files.f
+for line in fileinput.input("sim/ncompile/src_ips_files.f", inplace=True):
+    line = line.strip('\n')
+    if not 'tb/tb_hwpe' in line:
+        print(line)
 
 print(tcolors.OK + "Generated new scripts for IPs!" + tcolors.ENDC)
 

--- a/generate-scripts
+++ b/generate-scripts
@@ -14,6 +14,13 @@ execute("rm -rf sim/vcompile/rtl/*")
 execute("mkdir -p sim/vcompile/tb")
 execute("rm -rf sim/vcompile/tb/*")
 
+execute("mkdir -p sim/ncompile/ips")
+execute("rm -rf sim/ncompile/ips/*")
+execute("mkdir -p sim/ncompile/rtl")
+execute("rm -rf sim/ncompile/rtl/*")
+execute("mkdir -p sim/ncompile/tb")
+execute("rm -rf sim/ncompile/tb/*")
+
 # creates an IPApproX database
 ipdb = ipstools.IPDatabase(rtl_dir='rtl', ips_dir='ips', vsim_dir='sim', load_cache=True)
 

--- a/sim/Makefile.incisive
+++ b/sim/Makefile.incisive
@@ -16,8 +16,8 @@
 # Generally you just need to call make -f Makefile.incisive sim-sc to simulate
 # or make -f Makefile.incisive build-sc to just build
 
-.PHONY: build-r build-sc build-mc lib-r sim-r sim-sc sim-mc
-.PHONY: clean clean-r clean-sc clean-mc
+.PHONY: build-r build-sc build-mc lib-r sim-r sim-sc sim-mc build-deps
+.PHONY: clean clean-r clean-sc clean-mc clean-deps
 
 mkfile_path := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 
@@ -29,10 +29,16 @@ RTLLIBS	    = -reflib ncsim_libs
 SVLIB	    =  ../rtl/tb/remote_bitbang/librbs
 VISIBILITY  = -access +r
 
+# build the bitbang library, needed for simulating a jtag bridge to OpenOCD
+build-deps:
+	$(MAKE) -C ../rtl/tb/remote_bitbang all
+
+clean-deps:
+	$(MAKE) -C ../rtl/tb/remote_bitbang clean
 
 # -allowredefinition is neede because we unfortunately got two
 # modules named axi_slice_dc_slave_wrap and axi_slice_dc_master_wrap
-sim-sc:
+sim-sc: build-deps
 	$(XRUN) -64bit -top tb_pulp $(TIMESCALE) $(WARNINGS) \
 		-sv -v93 -allowredefinition \
 		-sv_lib $(SVLIB) \
@@ -45,7 +51,7 @@ sim-sc:
 		-f ncompile/src_rtl_files.f
 
 # this target is currently broken because the parser chokes on dpi_model.sv
-sim-mc:
+sim-mc: build-deps
 	$(XRUN) -64bit $(TIMESCALE) $(WARNINGS) \
 		-mce -mce_top tb_pulp \
 		-sv -v93 -allowredefinition \
@@ -54,7 +60,7 @@ sim-mc:
 		-f ncompile/src_rtl_files.f
 
 # -v93 is required for the FLL
-build-sc:
+build-sc: build-deps
 	$(XRUN) -64bit -elaborate $(TIMESCALE) $(WARNINGS) \
 		-top tb_pulp \
 		-sv -v93 -allowredefinition \
@@ -62,7 +68,7 @@ build-sc:
 		-f ncompile/src_ips_files.f \
 		-f ncompile/src_rtl_files.f
 
-build-mc:
+build-mc: build-deps
 	$(XRUN) -64bit -elaborate $(TIMESCALE) $(WARNINGS) \
 		-mce -mce_top tb_pulp \
 		-sv -v93 -allowredefinition \
@@ -99,4 +105,4 @@ clean-r:
 	@make --no-print-directory -f $(mkfile_path)/ncompile/rtl.mk clean
 
 
-clean: clean-r clean-mc clean-sc
+clean: clean-r clean-mc clean-sc clean-deps

--- a/sim/Makefile.incisive
+++ b/sim/Makefile.incisive
@@ -1,0 +1,102 @@
+# Copyright 2019 ETH Zurich and University of Bologna
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# How to compile/elaborate/run:
+# Generally you just need to call make -f Makefile.incisive sim-sc to simulate
+# or make -f Makefile.incisive build-sc to just build
+
+.PHONY: build-r build-sc build-mc lib-r sim-r sim-sc sim-mc
+.PHONY: clean clean-r clean-sc clean-mc
+
+mkfile_path := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
+
+XRUN	    ?= xrun
+XRUN_FLAGS  =
+TIMESCALE   = -timescale 1ps/1ps
+WARNINGS    = -warn_multiple_driver -nowarn NONPRT
+RTLLIBS	    = -reflib ncsim_libs
+SVLIB	    =  ../rtl/tb/remote_bitbang/librbs
+VISIBILITY  = -access +r
+
+
+# -allowredefinition is neede because we unfortunately got two
+# modules named axi_slice_dc_slave_wrap and axi_slice_dc_master_wrap
+sim-sc:
+	$(XRUN) -64bit -top tb_pulp $(TIMESCALE) $(WARNINGS) \
+		-sv -v93 -allowredefinition \
+		-sv_lib $(SVLIB) \
+		-defparam tb_pulp.USE_SDVT_SPI=0 -defparam tb_pulp.USE_SDVT_CPI=0 \
+		-defparam tb_pulp.BAUDRATE=115200 -defparam tb_pulp.ENABLE_DEV_DPI=0 \
+		-defparam tb_pulp.LOAD_L2=JTAG -defparam tb_pulp.USE_SDVT_I2S=0 \
+		-defparam tb_pulp.USE_PULP_BUS_ACCESS=1 \
+		$(VISIBILITY) $(XRUN_FLAGS) \
+		-f ncompile/src_ips_files.f \
+		-f ncompile/src_rtl_files.f
+
+# this target is currently broken because the parser chokes on dpi_model.sv
+sim-mc:
+	$(XRUN) -64bit $(TIMESCALE) $(WARNINGS) \
+		-mce -mce_top tb_pulp \
+		-sv -v93 -allowredefinition \
+		$(XRUN_FLAGS) \
+		-f ncompile/src_ips_files.f \
+		-f ncompile/src_rtl_files.f
+
+# -v93 is required for the FLL
+build-sc:
+	$(XRUN) -64bit -elaborate $(TIMESCALE) $(WARNINGS) \
+		-top tb_pulp \
+		-sv -v93 -allowredefinition \
+		 $(VISIBILITY) $(XRUN_FLAGS) \
+		-f ncompile/src_ips_files.f \
+		-f ncompile/src_rtl_files.f
+
+build-mc:
+	$(XRUN) -64bit -elaborate $(TIMESCALE) $(WARNINGS) \
+		-mce -mce_top tb_pulp \
+		-sv -v93 -allowredefinition \
+		$(XRUN_FLAGS) \
+		-f ncompile/src_ips_files.f \
+		-f ncompile/src_rtl_files.f
+
+clean-mc:
+clean-sc:
+	$(XRUN) -clean
+
+# "recursive building" i.e. building libraries and linking them is also
+# supported for ncsim/xcelium but It won't support multi-core simulation
+sim-r:
+	$(XRUN) -64bit -top tb_pulp $(TIMESCALE) $(WARNINGS) \
+		-sv_lib $(SVLIB) \
+		-defparam tb_pulp.USE_SDVT_SPI=0 -defparam tb_pulp.USE_SDVT_CPI=0 \
+		-defparam tb_pulp.BAUDRATE=115200 -defparam tb_pulp.ENABLE_DEV_DPI=0 \
+		-defparam tb_pulp.LOAD_L2=JTAG -defparam tb_pulp.USE_SDVT_I2S=0 \
+		-defparam tb_pulp.USE_PULP_BUS_ACCESS=1 \
+		$(VISIBILITY) $(XRUN_FLAGS) \
+		$(RTLLIBS)
+
+build-r:
+	@make --no-print-directory -f $(mkfile_path)/ncompile/ips.mk build
+	@make --no-print-directory -f $(mkfile_path)/ncompile/rtl.mk build
+
+lib-r:
+	@make --no-print-directory -f $(mkfile_path)/ncompile/ips.mk lib
+	@make --no-print-directory -f $(mkfile_path)/ncompile/rtl.mk lib
+
+clean-r:
+	@make --no-print-directory -f $(mkfile_path)/ncompile/ips.mk clean
+	@make --no-print-directory -f $(mkfile_path)/ncompile/rtl.mk clean
+
+
+clean: clean-r clean-mc clean-sc

--- a/sim/ncompile/build.mk
+++ b/sim/ncompile/build.mk
@@ -1,0 +1,61 @@
+#
+# Copyright (C) 2019 ETH Zurich, University of Bologna
+# All rights reserved.
+#
+# This software may be modified and distributed under the terms
+# of the BSD license.  See the LICENSE file for details.
+#
+
+# fix for colors on Ubuntu
+SHELL=/bin/bash
+
+# colors
+Green=\e[0;92m
+Yellow=\e[0;93m
+Red=\e[0;91m
+NC=\e[0;0m
+Blue=\e[0;94m
+
+# paths
+VSIM_PATH?	=.
+PULP_PATH?	=../..
+NCSIM_LIBS_PATH	=$(VSIM_PATH)/ncsim_libs
+IPS_PATH	=../ips
+RTL_PATH	=../rtl
+TB_PATH		=../tb
+LIB_PATH	=$(NCSIM_LIBS_PATH)/$(LIB_NAME)
+
+XRUN 		?= xrun
+
+# commands
+ifndef VERBOSE
+	SVLOG_CC=$(XRUN) -64bit -sv -access +r -compile -nowarn NONPRT
+	VLOG_CC=$(XRUN) -64bit -access +r -compile -nowarn NONPRT
+	VHDL_CC=$(XRUN) -64bit -v93 -access +r -compile -nowarn NONPRT
+	subip_echo=@echo -e "  $(NC)Building $(Yellow)$(IP)$(NC)/$(Yellow)$(1)$(NC)"
+	ip_echo=@echo -e "$(Green)Built$(NC) $(Yellow)$(IP)$(NC)"
+else
+	SVLOG_CC=$(XRUN) -64bit -sv -access +r -compile -nowarn NONPRT
+	VLOG_CC=$(XRUN) -64bit -access +r -compile -nowarn NONPRT
+	VHDL_CC=$(XRUN) -64bit -v93 -access +r -compile -nowarn NONPRT
+	subip_echo=@echo -e "\n$(NC)Building $(Yellow)$(IP)$(NC)/$(Yellow)$(1)$(NC)"
+	ip_echo=@echo -e "\n$(Green)Built$(NC) $(Yellow)$(IP)$(NC)"
+endif
+
+# rules
+.PHONY: build lib clean
+
+build: ncompile-$(IP)
+	@true
+
+lib: $(LIB_PATH)
+
+$(LIB_PATH): $(NCSIM_LIBS_PATH)
+# $(LIB_CREATE) $(LIB_PATH)
+# $(LIB_MAP) $(LIB_NAME) $(LIB_PATH)
+
+$(NCSIM_LIBS_PATH):
+	mkdir -p $(NCSIM_LIBS_PATH)
+
+clean:
+	rm -rf $(LIB_PATH)


### PR DESCRIPTION
In general it suffices to call `make -f Makefile.incisive sim-sc` to
compile, elaborate and run a simulation. Consider using setting
`XRUN=+stim=path_to_stimuli_file` to load a specific program. There is no
pulp-sdk support yet.

The targets *-sc (sim-sc, build-sc) are doing a direct compilation and
elaboration of all required files (see `src_ips_files.f` and
`src_rtl_files.f`) at once, while *-r (sim-r, build-r, lib-r) are targets
that provide a library plus link flow our questasim build. As of now it
is not clear which one is superior, though the first one would allow us
to do multi-core simulations but this is not yet working.

Thus:
Prefer to use sim-sc/build-sc over the other build commands.