### PR TITLE
Small fixes for Quartus compatibility

### DIFF
--- a/rtl/includes/periph_bus_defines.sv
+++ b/rtl/includes/periph_bus_defines.sv
@@ -68,6 +68,6 @@
     assign lhs.penable  = rhs.penable; \
     assign rhs.prdata   = lhs.prdata;  \
     assign rhs.pready   = lhs.pready;  \
-    assign rhs.pslverr  = lhs.pslverr;
+    assign rhs.pslverr  = lhs.pslverr
 
 `define APB_ASSIGN_MASTER(lhs, rhs) `APB_ASSIGN_SLAVE(rhs, lhs)

--- a/rtl/pulpissimo/safe_domain.sv
+++ b/rtl/pulpissimo/safe_domain.sv
@@ -464,9 +464,9 @@ module safe_domain
 
     generate
        for (i=0; i<32; i++)
-	 begin
+	 begin : GEN_GPIO_CFG_I
 	    for (j=0; j<6; j++)
-	      begin
+	      begin : GEN_GPIO_CFG_J
 		 assign s_gpio_cfg[i][j] = gpio_cfg_i[j+6*i];
 	      end
 	 end


### PR DESCRIPTION
In reference to: #78 

Fixed errors:

- `periph_bus_defines.sv`: [double semicolon](https://github.com/MarekPikula/quartus-sv-gotchas/blob/master/Intel%20Quartus%20SystemVerilog%20gotchas.md#double-semicolon)
- `rtl/pulpissimo/safe_domain.sv`: [unnamed loop generate](https://github.com/MarekPikula/quartus-sv-gotchas/blob/master/Intel%20Quartus%20SystemVerilog%20gotchas.md#274-loop-generate-constructs-3)