### PR TITLE
Add clock divider in slow_clk_gen to generate 32kHz slow clock

### DIFF
--- a/fpga/pulpissimo-genesys2/fpga-settings.mk
+++ b/fpga/pulpissimo-genesys2/fpga-settings.mk
@@ -3,7 +3,7 @@ export XILINX_PART=xc7k325tffg900-2
 export XILINX_BOARD=digilentinc.com:genesys2:part0:1.1
 export FC_CLK_PERIOD_NS=50
 export PER_CLK_PERIOD_NS=100
-export SLOW_CLK_PERIOD_NS=100
+export SLOW_CLK_PERIOD_NS=30517
 #Must also change the localparam 'L2_BANK_SIZE' in pulp_soc.sv accordingly
 export INTERLEAVED_BANK_SIZE=28672
 #Must also change the localparam 'L2_BANK_SIZE_PRI' in pulp_soc.sv accordingly

--- a/fpga/pulpissimo-genesys2/ips/xilinx_slow_clk_mngr/tcl/run.tcl
+++ b/fpga/pulpissimo-genesys2/ips/xilinx_slow_clk_mngr/tcl/run.tcl
@@ -14,11 +14,12 @@ if [info exists ::env(XILINX_BOARD)] {
 if [info exists ::env(SLOW_CLK_PERIOD_NS)] {
     set SLOW_CLK_PERIOD_NS $::env(SLOW_CLK_PERIOD_NS)
 } else {
-    set SLOW_CLK_PERIOD_NS 10.000
+    set SLOW_CLK_PERIOD_NS 30517
 }
 
-
-set SLOW_CLK_FREQ_MHZ [expr 1000 / $SLOW_CLK_PERIOD_NS]
+# Multiply frequency by 250 as there is a clock divider (by 250) after the
+# slow_clk_mngr since the MMCMs do not support clocks slower then 4.69 MHz.
+set SLOW_CLK_FREQ_MHZ [expr 1000 * 256 / $SLOW_CLK_PERIOD_NS]
 
 set ipName xilinx_slow_clk_mngr
 

--- a/fpga/pulpissimo-genesys2/rtl/fpga_slow_clk_gen.sv
+++ b/fpga/pulpissimo-genesys2/rtl/fpga_slow_clk_gen.sv
@@ -22,16 +22,61 @@
 
 
 module fpga_slow_clk_gen
+  #(
+    parameter CLK_DIV_VALUE = 256 //The xilinx_slow_clk_mngr is supposed to
+                                  //generate an 8.3886MHz clock. We need to divide it
+                                  //by 256 to arrive to a 32.768kHz clock
+    )
   (input logic ref_clk_i,
    input logic rst_ni,
    output logic slow_clk_o
    );
 
+
+
+  localparam COUNTER_WIDTH = $clog2(CLK_DIV_VALUE);
+
+
+  //Create clock divider using BUFGCE cells as the PLL/MMCM cannot generate clocks
+  //slower than 4.69 MHz and we need 32.768kHz
+
+  logic [COUNTER_WIDTH-1:0] clk_counter_d, clk_counter_q;
+  logic                     clock_gate_en;
+
+  logic                     intermmediate_clock;
+
   xilinx_slow_clk_mngr i_slow_clk_mngr
     (
      .resetn(rst_ni),
      .clk_in1(ref_clk_i),
-     .clk_out1(slow_clk_o)
+     .clk_out1(intermmediate_clock)
+     );
+
+
+
+  always_comb begin
+    if (clk_counter_q == CLK_DIV_VALUE-1) begin
+      clk_counter_d = '0;
+      clock_gate_en = 1'b1;
+    end else begin
+      clk_counter_d = clk_counter_q + 1;
+      clock_gate_en = 1'b0;
+    end
+  end
+
+  always_ff @(posedge intermmediate_clock, negedge rst_ni) begin
+    if (!rst_ni) begin
+      clk_counter_q <= '0;
+    end else begin
+      clk_counter_q <= clk_counter_d;
+    end
+  end
+
+  BUFGCE i_clock_gate
+    (
+      .I(intermmediate_clock),
+      .CE(clock_gate_en),
+      .O(slow_clk_o)
      );
 
 endmodule : fpga_slow_clk_gen

--- a/fpga/pulpissimo-nexys_video/fpga-settings.mk
+++ b/fpga/pulpissimo-nexys_video/fpga-settings.mk
@@ -3,7 +3,7 @@ export XILINX_PART=xc7a200tsbg484-1
 export XILINX_BOARD=digilentinc.com:nexys_video:1.1
 export FC_CLK_PERIOD_NS=100
 export PER_CLK_PERIOD_NS=200
-export SLOW_CLK_PERIOD_NS=200
+export SLOW_CLK_PERIOD_NS=30517
 #Must also change the localparam 'L2_BANK_SIZE' in pulp_soc.sv accordingly
 export INTERLEAVED_BANK_SIZE=28672
 #Must also change the localparam 'L2_BANK_SIZE_PRI' in pulp_soc.sv accordingly

--- a/fpga/pulpissimo-nexys_video/ips/xilinx_slow_clk_mngr/tcl/run.tcl
+++ b/fpga/pulpissimo-nexys_video/ips/xilinx_slow_clk_mngr/tcl/run.tcl
@@ -14,11 +14,12 @@ if [info exists ::env(XILINX_BOARD)] {
 if [info exists ::env(SLOW_CLK_PERIOD_NS)] {
     set SLOW_CLK_PERIOD_NS $::env(SLOW_CLK_PERIOD_NS)
 } else {
-    set SLOW_CLK_PERIOD_NS 10.000
+    set SLOW_CLK_PERIOD_NS 30517
 }
 
-
-set SLOW_CLK_FREQ_MHZ [expr 1000 / $SLOW_CLK_PERIOD_NS]
+# Multiply frequency by 250 as there is a clock divider (by 250) after the
+# slow_clk_mngr since the MMCMs do not support clocks slower then 4.69 MHz.
+set SLOW_CLK_FREQ_MHZ [expr 1000 * 256 / $SLOW_CLK_PERIOD_NS]
 
 set ipName xilinx_slow_clk_mngr
 

--- a/fpga/pulpissimo-nexys_video/rtl/fpga_slow_clk_gen.sv
+++ b/fpga/pulpissimo-nexys_video/rtl/fpga_slow_clk_gen.sv
@@ -22,16 +22,61 @@
 
 
 module fpga_slow_clk_gen
+  #(
+    parameter CLK_DIV_VALUE = 256 //The xilinx_slow_clk_mngr is supposed to
+                                  //generate an 8.3886MHz clock. We need to divide it
+                                  //by 256 to arrive to a 32.768kHz clock
+    )
   (input logic ref_clk_i,
    input logic rst_ni,
    output logic slow_clk_o
    );
 
+
+
+  localparam COUNTER_WIDTH = $clog2(CLK_DIV_VALUE);
+
+
+  //Create clock divider using BUFGCE cells as the PLL/MMCM cannot generate clocks
+  //slower than 4.69 MHz and we need 32.768kHz
+
+  logic [COUNTER_WIDTH-1:0] clk_counter_d, clk_counter_q;
+  logic                     clock_gate_en;
+
+  logic                     intermmediate_clock;
+
   xilinx_slow_clk_mngr i_slow_clk_mngr
     (
      .resetn(rst_ni),
      .clk_in1(ref_clk_i),
-     .clk_out1(slow_clk_o)
+     .clk_out1(intermmediate_clock)
+     );
+
+
+
+  always_comb begin
+    if (clk_counter_q == CLK_DIV_VALUE-1) begin
+      clk_counter_d = '0;
+      clock_gate_en = 1'b1;
+    end else begin
+      clk_counter_d = clk_counter_q + 1;
+      clock_gate_en = 1'b0;
+    end
+  end
+
+  always_ff @(posedge intermmediate_clock, negedge rst_ni) begin
+    if (!rst_ni) begin
+      clk_counter_q <= '0;
+    end else begin
+      clk_counter_q <= clk_counter_d;
+    end
+  end
+
+  BUFGCE i_clock_gate
+    (
+      .I(intermmediate_clock),
+      .CE(clock_gate_en),
+      .O(slow_clk_o)
      );
 
 endmodule : fpga_slow_clk_gen

--- a/fpga/pulpissimo-zcu104/fpga-settings.mk
+++ b/fpga/pulpissimo-zcu104/fpga-settings.mk
@@ -3,7 +3,7 @@ export XILINX_PART=xczu7ev-ffvc1156-2-e
 export XILINX_BOARD=xilinx.com:zcu104:part0:1.1
 export FC_CLK_PERIOD_NS=50
 export PER_CLK_PERIOD_NS=100
-export SLOW_CLK_PERIOD_NS=100
+export SLOW_CLK_PERIOD_NS=30517
 #Must also change the localparam 'L2_BANK_SIZE' in pulp_soc.sv accordingly
 export INTERLEAVED_BANK_SIZE=28672
 #Must also change the localparam 'L2_BANK_SIZE_PRI' in pulp_soc.sv accordingly

--- a/fpga/pulpissimo-zcu104/ips/xilinx_slow_clk_mngr/tcl/run.tcl
+++ b/fpga/pulpissimo-zcu104/ips/xilinx_slow_clk_mngr/tcl/run.tcl
@@ -14,11 +14,12 @@ if [info exists ::env(XILINX_BOARD)] {
 if [info exists ::env(SLOW_CLK_PERIOD_NS)] {
     set SLOW_CLK_PERIOD_NS $::env(SLOW_CLK_PERIOD_NS)
 } else {
-    set SLOW_CLK_PERIOD_NS 10.000
+    set SLOW_CLK_PERIOD_NS 30517
 }
 
-
-set SLOW_CLK_FREQ_MHZ [expr 1000 / $SLOW_CLK_PERIOD_NS]
+# Multiply frequency by 250 as there is a clock divider (by 250) after the
+# slow_clk_mngr since the MMCMs do not support clocks slower then 4.69 MHz.
+set SLOW_CLK_FREQ_MHZ [expr 1000 * 256 / $SLOW_CLK_PERIOD_NS]
 
 set ipName xilinx_slow_clk_mngr
 

--- a/fpga/pulpissimo-zcu104/rtl/fpga_slow_clk_gen.sv
+++ b/fpga/pulpissimo-zcu104/rtl/fpga_slow_clk_gen.sv
@@ -22,16 +22,61 @@
 
 
 module fpga_slow_clk_gen
+  #(
+    parameter CLK_DIV_VALUE = 256 //The xilinx_slow_clk_mngr is supposed to
+                                  //generate an 8.3886MHz clock. We need to divide it
+                                  //by 256 to arrive to a 32.768kHz clock
+    )
   (input logic ref_clk_i,
    input logic rst_ni,
    output logic slow_clk_o
    );
 
+
+
+  localparam COUNTER_WIDTH = $clog2(CLK_DIV_VALUE);
+
+
+  //Create clock divider using BUFGCE cells as the PLL/MMCM cannot generate clocks
+  //slower than 4.69 MHz and we need 32.768kHz
+
+  logic [COUNTER_WIDTH-1:0] clk_counter_d, clk_counter_q;
+  logic                     clock_gate_en;
+
+  logic                     intermmediate_clock;
+
   xilinx_slow_clk_mngr i_slow_clk_mngr
     (
      .resetn(rst_ni),
      .clk_in1(ref_clk_i),
-     .clk_out1(slow_clk_o)
+     .clk_out1(intermmediate_clock)
+     );
+
+
+
+  always_comb begin
+    if (clk_counter_q == CLK_DIV_VALUE-1) begin
+      clk_counter_d = '0;
+      clock_gate_en = 1'b1;
+    end else begin
+      clk_counter_d = clk_counter_q + 1;
+      clock_gate_en = 1'b0;
+    end
+  end
+
+  always_ff @(posedge intermmediate_clock, negedge rst_ni) begin
+    if (!rst_ni) begin
+      clk_counter_q <= '0;
+    end else begin
+      clk_counter_q <= clk_counter_d;
+    end
+  end
+
+  BUFGCE i_clock_gate
+    (
+      .I(intermmediate_clock),
+      .CE(clock_gate_en),
+      .O(slow_clk_o)
      );
 
 endmodule : fpga_slow_clk_gen


### PR DESCRIPTION
The pulp-sdk expects the slow clock to be 32kHZ. However, the MMCM/PLL resources on
the Xilinx FPGA do not support such low frequencies. We therefore generate an
intermediate clock (8 MHz) and slow it down with a clock divider using the
dedicated BUFCGE clock gating cells in conjunction with a counter.