### PR TITLE
Various fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -225,28 +225,28 @@ test_rt:
       junit: tests/rt-tests/junit-reports/TEST-*.xml
 
 # Use simplified pulp-runtime to run a subset of tests
-test_simplified_sw:
-  stage: test
-  before_script:
-    - echo "Fetching Runtime"
-    - make pulp-runtime
-    - echo "Compiling RTL model and DPI libraries"
-    - make build
-    - echo "Installing scripts"
-    - make install
-  script:
-    - echo "Running software test"
-    - source pulp-runtime/configs/pulpissimo.sh && make test-runtime-gitlab
-    - echo "Generating junit test results"
-    - /usr/sepp/bin/pip3.4 install --user junit2html
-    - /usr/sepp/bin/python3.4 -m junit2htmlreport tests/rt-tests/junit-reports/TEST-*.xml
-  artifacts:
-    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA"
-    paths:
-      - tests/*.html
-      - tests/*.xml
-    reports:
-      junit: tests/*.xml
+# test_simplified_sw:
+#   stage: test
+#   before_script:
+#     - echo "Fetching Runtime"
+#     - make pulp-runtime
+#     - echo "Compiling RTL model and DPI libraries"
+#     - make build
+#     - echo "Installing scripts"
+#     - make install
+#   script:
+#     - echo "Running software test"
+#     - source pulp-runtime/configs/pulpissimo.sh && make test-runtime-gitlab
+#     - echo "Generating junit test results"
+#     - /usr/sepp/bin/pip3.4 install --user junit2html
+#     - /usr/sepp/bin/python3.4 -m junit2htmlreport tests/rt-tests/junit-reports/TEST-*.xml
+#   artifacts:
+#     name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA"
+#     paths:
+#       - tests/*.html
+#       - tests/*.xml
+#     reports:
+#       junit: tests/*.xml
 
 # Built SDK with the `make sdk` target and run all tests
 # test_sw_build_sdk:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -237,6 +237,9 @@ test_simplified_sw:
   script:
     - echo "Running software test"
     - source pulp-runtime/configs/pulpissimo.sh && make test-runtime-gitlab
+    - echo "Generating junit test results"
+    - /usr/sepp/bin/pip3.4 install --user junit2html
+    - /usr/sepp/bin/python3.4 -m junit2htmlreport tests/rt-tests/junit-reports/TEST-*.xml
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA"
     paths:

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -19,7 +19,7 @@
 #
 
 pulp_soc:
-  commit: v1.3.0
+  commit: v1.4.1
   server: https://github.com
   group:  pulp-platform
 

--- a/sim/waves/core.tcl
+++ b/sim/waves/core.tcl
@@ -1,6 +1,6 @@
 # add fc
 set rvcores [find instances -recursive -bydu riscv_core -nodu]
-set fpuprivate [find instances -recursive -bydu fpu_private]
+set fpuprivate [find instances -recursive -bydu fpnew_top]
 set rvpmp [find instances -recursive -bydu riscv_pmp]
 
 if {$rvcores ne ""} {
@@ -28,7 +28,7 @@ if {$rvcores ne ""} {
   add wave -group "Core"  -group "EX Stage" -group "MUL"                    $rvcores/ex_stage_i/mult_i/*
   if {$fpuprivate ne ""} {
     add wave -group "Core"  -group "EX Stage" -group "APU_DISP"             $rvcores/ex_stage_i/genblk1/apu_disp_i/*
-    add wave -group "Core"  -group "EX Stage" -group "FPU"                  $rvcores/ex_stage_i/genblk1/genblk1/fpu_i/*
+    add wave -group "Core"  -group "EX Stage" -group "FPU"               $rvcores/ex_stage_i/genblk1/genblk1/i_fpnew_bulk/*
   }
   add wave -group "Core"  -group "EX Stage"                                 $rvcores/ex_stage_i/*
   add wave -group "Core"  -group "LSU"                                      $rvcores/load_store_unit_i/*

--- a/update-tests
+++ b/update-tests
@@ -19,7 +19,7 @@ git clone git@iis-git.ee.ethz.ch:pulp-sw/sequential_bare_tests.git \
 echo "Using stable versions of tests"
 git -C tests/ml_tests checkout -q 9c49595a3dd9a0a2a776518b7de6c2cda903142b
 git -C tests/pulp_tests checkout -q ce367a85b9d4b15e92b57cdfa7b715ecf6a92a45
-git -C tests/rt-tests checkout -q c19233304eb58a388c523e55d467f4abc666358f
+git -C tests/rt-tests checkout -q 5e736972b8ea6d3d7740dcfb28df002824dad2ac
 git -C tests/parallel_bare_tests checkout -q 91b1bad09d088df9140f5391a87df3f6ebfab344
 git -C tests/riscv_tests checkout -q 2ce43f33cc6f983e4deb3f79dec9663e02c10af5
 git -C tests/sequential_bare_tests checkout -q f2cf176414a779b7fae31836d137cfaf6e78b719

--- a/update-tests
+++ b/update-tests
@@ -17,7 +17,7 @@ git clone git@iis-git.ee.ethz.ch:pulp-sw/sequential_bare_tests.git \
 
 # using "stable" versions
 echo "Using stable versions of tests"
-git -C tests/ml_tests checkout -q 481c83b30c2cb7b823d1769b1c0d6a30a3a3b9b0
+git -C tests/ml_tests checkout -q 9c49595a3dd9a0a2a776518b7de6c2cda903142b
 git -C tests/pulp_tests checkout -q ce367a85b9d4b15e92b57cdfa7b715ecf6a92a45
 git -C tests/rt-tests checkout -q c19233304eb58a388c523e55d467f4abc666358f
 git -C tests/parallel_bare_tests checkout -q 91b1bad09d088df9140f5391a87df3f6ebfab344

--- a/update-tests
+++ b/update-tests
@@ -19,7 +19,7 @@ git clone git@iis-git.ee.ethz.ch:pulp-sw/sequential_bare_tests.git \
 echo "Using stable versions of tests"
 git -C tests/ml_tests checkout -q 9c49595a3dd9a0a2a776518b7de6c2cda903142b
 git -C tests/pulp_tests checkout -q ce367a85b9d4b15e92b57cdfa7b715ecf6a92a45
-git -C tests/rt-tests checkout -q 5e736972b8ea6d3d7740dcfb28df002824dad2ac
+git -C tests/rt-tests checkout -q f6bfda35cdbd363a94e7c8957fa7efc27093b106
 git -C tests/parallel_bare_tests checkout -q 91b1bad09d088df9140f5391a87df3f6ebfab344
 git -C tests/riscv_tests checkout -q 2ce43f33cc6f983e4deb3f79dec9663e02c10af5
 git -C tests/sequential_bare_tests checkout -q f2cf176414a779b7fae31836d137cfaf6e78b719

--- a/update-tests-gitlab
+++ b/update-tests-gitlab
@@ -21,7 +21,7 @@ git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@${GITLAB}/pulp-sw/sequential_b
 echo "Using stable versions of tests"
 git -C tests/ml_tests checkout -q 9c49595a3dd9a0a2a776518b7de6c2cda903142b
 git -C tests/pulp_tests checkout -q ce367a85b9d4b15e92b57cdfa7b715ecf6a92a45
-git -C tests/rt-tests checkout -q c19233304eb58a388c523e55d467f4abc666358f
+git -C tests/rt-tests checkout -q 5e736972b8ea6d3d7740dcfb28df002824dad2ac
 git -C tests/parallel_bare_tests checkout -q 91b1bad09d088df9140f5391a87df3f6ebfab344
 git -C tests/riscv_tests checkout -q 2ce43f33cc6f983e4deb3f79dec9663e02c10af5
 git -C tests/sequential_bare_tests checkout -q f2cf176414a779b7fae31836d137cfaf6e78b719

--- a/update-tests-gitlab
+++ b/update-tests-gitlab
@@ -21,7 +21,7 @@ git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@${GITLAB}/pulp-sw/sequential_b
 echo "Using stable versions of tests"
 git -C tests/ml_tests checkout -q 9c49595a3dd9a0a2a776518b7de6c2cda903142b
 git -C tests/pulp_tests checkout -q ce367a85b9d4b15e92b57cdfa7b715ecf6a92a45
-git -C tests/rt-tests checkout -q 5e736972b8ea6d3d7740dcfb28df002824dad2ac
+git -C tests/rt-tests checkout -q f6bfda35cdbd363a94e7c8957fa7efc27093b106
 git -C tests/parallel_bare_tests checkout -q 91b1bad09d088df9140f5391a87df3f6ebfab344
 git -C tests/riscv_tests checkout -q 2ce43f33cc6f983e4deb3f79dec9663e02c10af5
 git -C tests/sequential_bare_tests checkout -q f2cf176414a779b7fae31836d137cfaf6e78b719

--- a/update-tests-gitlab
+++ b/update-tests-gitlab
@@ -19,7 +19,7 @@ git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@${GITLAB}/pulp-sw/sequential_b
 
 # using "stable" versions
 echo "Using stable versions of tests"
-git -C tests/ml_tests checkout -q 481c83b30c2cb7b823d1769b1c0d6a30a3a3b9b0
+git -C tests/ml_tests checkout -q 9c49595a3dd9a0a2a776518b7de6c2cda903142b
 git -C tests/pulp_tests checkout -q ce367a85b9d4b15e92b57cdfa7b715ecf6a92a45
 git -C tests/rt-tests checkout -q c19233304eb58a388c523e55d467f4abc666358f
 git -C tests/parallel_bare_tests checkout -q 91b1bad09d088df9140f5391a87df3f6ebfab344


### PR DESCRIPTION
* Disable deprecated tests in `rt-tests`
* Disable simplified runtime tests (we have to carefully enabled these)
* Fix `ml_tests` (mlHom, mlFir, seizure)