### PR TITLE
Enable FPU on Zedboard

### DIFF
--- a/fpga/pulpissimo-zedboard/rtl/xilinx_pulpissimo.v
+++ b/fpga/pulpissimo-zedboard/rtl/xilinx_pulpissimo.v
@@ -69,7 +69,7 @@ module xilinx_pulpissimo (
  );
 
   localparam CORE_TYPE = 0; // 0 for RISCY, 1 for IBEX RV32IMC (formerly ZERORISCY), 2 for IBEX RV32EC (formerly MICRORISCY)
-  localparam USE_FPU   = 0;
+  localparam USE_FPU   = 1;
   localparam USE_HWPE  = 0;
 
   wire ref_clk_int;


### PR DESCRIPTION
All other implementations have this module enabled and
rudimentary tests show that it works just fine.