### PR TITLE
Fix fpga timing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -284,7 +284,7 @@ test_dm:
     - echo "Running debug module testbench"
     - cd sim/ && make lib build opt simc VSIM_FLAGS=-gENABLE_DM_TESTS=1
 
-fpga_synth:
+fpga_synth_genesys2:
   stage: test
   before_script:
   script:
@@ -310,3 +310,138 @@ fpga_synth:
       - fpga/pulpissimo-genesys2/*.gdb
       - fpga/pulpissimo-genesys2/*.jou
       - fpga/pulpissimo-genesys2/*.log
+
+fpga_synth_nexys_video:
+  stage: test
+  before_script:
+  script:
+    - echo "(Re)generating scripts" # because paths might have changed
+    - ./generate-scripts
+    - echo "Starting synthesis with vivado"
+    - cd fpga/ && make nexys_video VIVADO='vivado-2019.1.1 vivado'
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA"
+    paths:
+      - fpga/pulpissimo_nexys_video.bit
+      - fpga/pulpissimo_nexys_video.bin
+      - fpga/*.jou
+      - fpga/*.log
+      - fpga/*.str
+      - fpga/pulpissimo-nexys_video/reports
+      - fpga/pulpissimo-nexys_video/rtl
+      - fpga/pulpissimo-nexys_video/tcl
+      - fpga/pulpissimo-nexys_video/pulpissimo_nexys_video.xpr
+      - fpga/pulpissimo-nexys_video/fpga-settings.mk
+      - fpga/pulpissimo-nexys_video/*.log
+      - fpga/pulpissimo-nexys_video/*.cfg
+      - fpga/pulpissimo-nexys_video/*.gdb
+      - fpga/pulpissimo-nexys_video/*.jou
+      - fpga/pulpissimo-nexys_video/*.log
+
+fpga_synth_nexys:
+  stage: test
+  before_script:
+  script:
+    - echo "(Re)generating scripts" # because paths might have changed
+    - ./generate-scripts
+    - echo "Starting synthesis with vivado"
+    - cd fpga/ && make nexys rev=nexys4 VIVADO='vivado-2019.1.1 vivado'
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA"
+    paths:
+      - fpga/pulpissimo_nexys.bit
+      - fpga/pulpissimo_nexys.bin
+      - fpga/*.jou
+      - fpga/*.log
+      - fpga/*.str
+      - fpga/pulpissimo-nexys/reports
+      - fpga/pulpissimo-nexys/rtl
+      - fpga/pulpissimo-nexys/tcl
+      - fpga/pulpissimo-nexys/pulpissimo_nexys.xpr
+      - fpga/pulpissimo-nexys/fpga-settings.mk
+      - fpga/pulpissimo-nexys/*.log
+      - fpga/pulpissimo-nexys/*.cfg
+      - fpga/pulpissimo-nexys/*.gdb
+      - fpga/pulpissimo-nexys/*.jou
+      - fpga/pulpissimo-nexys/*.log
+
+fpga_synth_nexys_zcu104:
+  stage: test
+  before_script:
+  script:
+    - echo "(Re)generating scripts" # because paths might have changed
+    - ./generate-scripts
+    - echo "Starting synthesis with vivado"
+    - cd fpga/ && make zcu104 VIVADO='vivado-2019.1.1 vivado'
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA"
+    paths:
+      - fpga/pulpissimo_zcu104.bit
+      - fpga/pulpissimo_zcu104.bin
+      - fpga/*.jou
+      - fpga/*.log
+      - fpga/*.str
+      - fpga/pulpissimo-zcu104/reports
+      - fpga/pulpissimo-zcu104/rtl
+      - fpga/pulpissimo-zcu104/tcl
+      - fpga/pulpissimo-zcu104/pulpissimo_zcu104.xpr
+      - fpga/pulpissimo-zcu104/fpga-settings.mk
+      - fpga/pulpissimo-zcu104/*.log
+      - fpga/pulpissimo-zcu104/*.cfg
+      - fpga/pulpissimo-zcu104/*.gdb
+      - fpga/pulpissimo-zcu104/*.jou
+      - fpga/pulpissimo-zcu104/*.log
+
+fpga_synth_zedboard:
+  stage: test
+  before_script:
+  script:
+    - echo "(Re)generating scripts" # because paths might have changed
+    - ./generate-scripts
+    - echo "Starting synthesis with vivado"
+    - cd fpga/ && make zedboard VIVADO='vivado-2019.1.1 vivado'
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA"
+    paths:
+      - fpga/pulpissimo_zedboard.bit
+      - fpga/pulpissimo_zedboard.bin
+      - fpga/*.jou
+      - fpga/*.log
+      - fpga/*.str
+      - fpga/pulpissimo-zedboard/reports
+      - fpga/pulpissimo-zedboard/rtl
+      - fpga/pulpissimo-zedboard/tcl
+      - fpga/pulpissimo-zedboard/pulpissimo_zedboard.xpr
+      - fpga/pulpissimo-zedboard/fpga-settings.mk
+      - fpga/pulpissimo-zedboard/*.log
+      - fpga/pulpissimo-zedboard/*.cfg
+      - fpga/pulpissimo-zedboard/*.gdb
+      - fpga/pulpissimo-zedboard/*.jou
+      - fpga/pulpissimo-zedboard/*.log
+
+fpga_synth_zcu102:
+  stage: test
+  before_script:
+  script:
+    - echo "(Re)generating scripts" # because paths might have changed
+    - ./generate-scripts
+    - echo "Starting synthesis with vivado"
+    - cd fpga/ && make zcu102 VIVADO='vivado-2019.1.1 vivado'
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA"
+    paths:
+      - fpga/pulpissimo_zcu102.bit
+      - fpga/pulpissimo_zcu102.bin
+      - fpga/*.jou
+      - fpga/*.log
+      - fpga/*.str
+      - fpga/pulpissimo-zcu102/reports
+      - fpga/pulpissimo-zcu102/rtl
+      - fpga/pulpissimo-zcu102/tcl
+      - fpga/pulpissimo-zcu102/pulpissimo_zcu102.xpr
+      - fpga/pulpissimo-zcu102/fpga-settings.mk
+      - fpga/pulpissimo-zcu102/*.log
+      - fpga/pulpissimo-zcu102/*.cfg
+      - fpga/pulpissimo-zcu102/*.gdb
+      - fpga/pulpissimo-zcu102/*.jou
+      - fpga/pulpissimo-zcu102/*.log

--- a/fpga/pulpissimo-genesys2/constraints/genesys2.xdc
+++ b/fpga/pulpissimo-genesys2/constraints/genesys2.xdc
@@ -57,6 +57,12 @@ set_property ASYNC_REG true [get_cells i_pulpissimo/soc_domain_i/pulp_soc_i/soc_
 # are considered asynchronously and proper synchronization regs are in place
 set_clock_groups -asynchronous -group [get_clocks -of_objects [get_pins i_pulpissimo/safe_domain_i/i_slow_clk_gen/i_slow_clk_mngr/inst/mmcm_adv_inst/CLKOUT0]] -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/i_fpga_clk_gen/i_clk_manager/inst/mmcm_adv_inst/CLKOUT0]]
 
+# Create asynchronous clock group between Per Clock  and SoC clock. Those clocks
+# are considered asynchronously and proper synchronization regs are in place
+set_clock_groups -asynchronous -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/clk_per_o]] -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/clk_soc_o]]
+
+# Create asynchronous clock group between JTAG TCK and SoC clock.
+set_clock_groups -asynchronous -group [get_clocks -of_objects [get_pins i_pulpissimo/pad_jtag_tck]] -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/clk_soc_o]]
 
 #############################################################
 #  _____ ____         _____      _   _   _                  #

--- a/fpga/pulpissimo-genesys2/rtl/pulp_clock_gating_xilinx.sv
+++ b/fpga/pulpissimo-genesys2/rtl/pulp_clock_gating_xilinx.sv
@@ -15,7 +15,13 @@ module pulp_clock_gating
    input  logic test_en_i,
    output logic clk_o
    );
+  logic         clk_en;
 
-   assign clk_o = clk_i;
-   
+  // Use a latch based clock gate instead of BUFGCE. Otherwise we quickly run out of BUFGCTRL cells on the FPGAs.
+  always_latch begin
+    if (clk_i == 1'b0) clk_en <= en_i | test_en_i;
+  end
+
+  assign clk_o = clk_i & clk_en;
+
 endmodule

--- a/fpga/pulpissimo-nexys/constraints/nexys4.xdc
+++ b/fpga/pulpissimo-nexys/constraints/nexys4.xdc
@@ -68,6 +68,12 @@ set_property ASYNC_REG true [get_cells i_pulpissimo/soc_domain_i/pulp_soc_i/soc_
 # are considered asynchronously and proper synchronization regs are in place
 set_clock_groups -asynchronous -group [get_clocks -of_objects [get_pins i_pulpissimo/safe_domain_i/i_slow_clk_gen/i_slow_clk_mngr/inst/mmcm_adv_inst/CLKOUT0]] -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/i_fpga_clk_gen/i_clk_manager/inst/mmcm_adv_inst/CLKOUT0]]
 
+# Create asynchronous clock group between Per Clock  and SoC clock. Those clocks
+# are considered asynchronously and proper synchronization regs are in place
+set_clock_groups -asynchronous -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/clk_per_o]] -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/clk_soc_o]]
+
+# Create asynchronous clock group between JTAG TCK and SoC clock.
+set_clock_groups -asynchronous -group [get_clocks -of_objects [get_pins i_pulpissimo/pad_jtag_tck]] -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/clk_soc_o]]
 
 #############################################################
 #  _____ ____         _____      _   _   _                  #

--- a/fpga/pulpissimo-nexys/constraints/nexys4DDR.xdc
+++ b/fpga/pulpissimo-nexys/constraints/nexys4DDR.xdc
@@ -71,6 +71,12 @@ set_property ASYNC_REG true [get_cells i_pulpissimo/soc_domain_i/pulp_soc_i/soc_
 # are considered asynchronously and proper synchronization regs are in place
 set_clock_groups -asynchronous -group [get_clocks -of_objects [get_pins i_pulpissimo/safe_domain_i/i_slow_clk_gen/i_slow_clk_mngr/inst/mmcm_adv_inst/CLKOUT0]] -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/i_fpga_clk_gen/i_clk_manager/inst/mmcm_adv_inst/CLKOUT0]]
 
+# Create asynchronous clock group between Per Clock  and SoC clock. Those clocks
+# are considered asynchronously and proper synchronization regs are in place
+set_clock_groups -asynchronous -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/clk_per_o]] -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/clk_soc_o]]
+
+# Create asynchronous clock group between JTAG TCK and SoC clock.
+set_clock_groups -asynchronous -group [get_clocks -of_objects [get_pins i_pulpissimo/pad_jtag_tck]] -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/clk_soc_o]]
 
 #############################################################
 #  _____ ____         _____      _   _   _                  #

--- a/fpga/pulpissimo-nexys/rtl/pulp_clock_gating_xilinx.sv
+++ b/fpga/pulpissimo-nexys/rtl/pulp_clock_gating_xilinx.sv
@@ -15,7 +15,13 @@ module pulp_clock_gating
    input  logic test_en_i,
    output logic clk_o
    );
+  logic         clk_en;
 
-   assign clk_o = clk_i;
-   
+  // Use a latch based clock gate instead of BUFGCE. Otherwise we quickly run out of BUFGCTRL cells on the FPGAs.
+  always_latch begin
+    if (clk_i == 1'b0) clk_en <= en_i | test_en_i;
+  end
+
+  assign clk_o = clk_i & clk_en;
+
 endmodule

--- a/fpga/pulpissimo-nexys_video/constraints/nexys_video.xdc
+++ b/fpga/pulpissimo-nexys_video/constraints/nexys_video.xdc
@@ -57,6 +57,12 @@ set_property ASYNC_REG true [get_cells i_pulpissimo/soc_domain_i/pulp_soc_i/soc_
 # are considered asynchronously and proper synchronization regs are in place
 set_clock_groups -asynchronous -group [get_clocks -of_objects [get_pins i_pulpissimo/safe_domain_i/i_slow_clk_gen/i_slow_clk_mngr/inst/mmcm_adv_inst/CLKOUT0]] -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/i_fpga_clk_gen/i_clk_manager/inst/mmcm_adv_inst/CLKOUT0]]
 
+# Create asynchronous clock group between Per Clock  and SoC clock. Those clocks
+# are considered asynchronously and proper synchronization regs are in place
+set_clock_groups -asynchronous -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/clk_per_o]] -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/clk_soc_o]]
+
+# Create asynchronous clock group between JTAG TCK and SoC clock.
+set_clock_groups -asynchronous -group [get_clocks -of_objects [get_pins i_pulpissimo/pad_jtag_tck]] -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/clk_soc_o]]
 
 #############################################################
 #  _____ ____         _____      _   _   _                  #

--- a/fpga/pulpissimo-nexys_video/rtl/pulp_clock_gating_xilinx.sv
+++ b/fpga/pulpissimo-nexys_video/rtl/pulp_clock_gating_xilinx.sv
@@ -15,7 +15,13 @@ module pulp_clock_gating
    input  logic test_en_i,
    output logic clk_o
    );
+  logic         clk_en;
 
-   assign clk_o = clk_i;
-   
+  // Use a latch based clock gate instead of BUFGCE. Otherwise we quickly run out of BUFGCTRL cells on the FPGAs.
+  always_latch begin
+    if (clk_i == 1'b0) clk_en <= en_i | test_en_i;
+  end
+
+  assign clk_o = clk_i & clk_en;
+
 endmodule

--- a/fpga/pulpissimo-zcu102/constraints/zcu102.xdc
+++ b/fpga/pulpissimo-zcu102/constraints/zcu102.xdc
@@ -57,6 +57,12 @@ set_property ASYNC_REG true [get_cells i_pulpissimo/soc_domain_i/pulp_soc_i/soc_
 # are considered asynchronously and proper synchronization regs are in place
 set_clock_groups -asynchronous -group [get_clocks -of_objects [get_pins i_pulpissimo/safe_domain_i/i_slow_clk_gen/slow_clk_o]] -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/i_fpga_clk_gen/soc_clk_o]]
 
+# Create asynchronous clock group between Per Clock  and SoC clock. Those clocks
+# are considered asynchronously and proper synchronization regs are in place
+set_clock_groups -asynchronous -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/clk_per_o]] -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/clk_soc_o]]
+
+# Create asynchronous clock group between JTAG TCK and SoC clock.
+set_clock_groups -asynchronous -group [get_clocks -of_objects [get_pins i_pulpissimo/pad_jtag_tck]] -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/clk_soc_o]]
 
 #############################################################
 #  _____ ____         _____      _   _   _                  #

--- a/fpga/pulpissimo-zcu102/rtl/pulp_clock_gating_xilinx.sv
+++ b/fpga/pulpissimo-zcu102/rtl/pulp_clock_gating_xilinx.sv
@@ -15,7 +15,13 @@ module pulp_clock_gating
    input  logic test_en_i,
    output logic clk_o
    );
+  logic         clk_en;
 
-   assign clk_o = clk_i;
-   
+  // Use a latch based clock gate instead of BUFGCE. Otherwise we quickly run out of BUFGCTRL cells on the FPGAs.
+  always_latch begin
+    if (clk_i == 1'b0) clk_en <= en_i | test_en_i;
+  end
+
+  assign clk_o = clk_i & clk_en;
+
 endmodule

--- a/fpga/pulpissimo-zcu104/constraints/zcu104.xdc
+++ b/fpga/pulpissimo-zcu104/constraints/zcu104.xdc
@@ -56,6 +56,12 @@ set_property ASYNC_REG true [get_cells i_pulpissimo/soc_domain_i/pulp_soc_i/soc_
 # are considered asynchronously and proper synchronization regs are in place
 set_clock_groups -asynchronous -group [get_clocks -of_objects [get_pins i_pulpissimo/safe_domain_i/i_slow_clk_gen/slow_clk_o]] -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/i_fpga_clk_gen/soc_clk_o]]
 
+# Create asynchronous clock group between Per Clock  and SoC clock. Those clocks
+# are considered asynchronously and proper synchronization regs are in place
+set_clock_groups -asynchronous -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/clk_per_o]] -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/clk_soc_o]]
+
+# Create asynchronous clock group between JTAG TCK and SoC clock.
+set_clock_groups -asynchronous -group [get_clocks -of_objects [get_pins i_pulpissimo/pad_jtag_tck]] -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/clk_soc_o]]
 
 #############################################################
 #  _____ ____         _____      _   _   _                  #

--- a/fpga/pulpissimo-zcu104/rtl/pulp_clock_gating_xilinx.sv
+++ b/fpga/pulpissimo-zcu104/rtl/pulp_clock_gating_xilinx.sv
@@ -15,7 +15,13 @@ module pulp_clock_gating
    input  logic test_en_i,
    output logic clk_o
    );
+  logic         clk_en;
 
-   assign clk_o = clk_i;
-   
+  // Use a latch based clock gate instead of BUFGCE. Otherwise we quickly run out of BUFGCTRL cells on the FPGAs.
+  always_latch begin
+    if (clk_i == 1'b0) clk_en <= en_i | test_en_i;
+  end
+
+  assign clk_o = clk_i & clk_en;
+
 endmodule

--- a/fpga/pulpissimo-zedboard/constraints/zedboard.xdc
+++ b/fpga/pulpissimo-zedboard/constraints/zedboard.xdc
@@ -58,6 +58,12 @@ set_property ASYNC_REG true [get_cells i_pulpissimo/soc_domain_i/pulp_soc_i/soc_
 # are considered asynchronously and proper synchronization regs are in place
 set_clock_groups -asynchronous -group [get_clocks -of_objects [get_pins i_pulpissimo/safe_domain_i/i_slow_clk_gen/slow_clk_o]] -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/i_fpga_clk_gen/soc_clk_o]]
 
+# Create asynchronous clock group between Per Clock  and SoC clock. Those clocks
+# are considered asynchronously and proper synchronization regs are in place
+set_clock_groups -asynchronous -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/clk_per_o]] -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/clk_soc_o]]
+
+# Create asynchronous clock group between JTAG TCK and SoC clock.
+set_clock_groups -asynchronous -group [get_clocks -of_objects [get_pins i_pulpissimo/pad_jtag_tck]] -group [get_clocks -of_objects [get_pins i_pulpissimo/soc_domain_i/pulp_soc_i/i_clk_rst_gen/clk_soc_o]]
 
 #############################################################
 #  _____ ____         _____      _   _   _                  #

--- a/fpga/pulpissimo-zedboard/fpga-settings.mk
+++ b/fpga/pulpissimo-zedboard/fpga-settings.mk
@@ -1,7 +1,7 @@
 export BOARD=zedboard
 export XILINX_PART=xc7z020clg484-1
 export XILINX_BOARD=em.avnet.com:zed:part0:1.4
-export FC_CLK_PERIOD_NS=50
+export FC_CLK_PERIOD_NS=62.5
 export PER_CLK_PERIOD_NS=100
 export SLOW_CLK_PERIOD_NS=30517
 #Must also change the localparam 'L2_BANK_SIZE' in pulp_soc.sv accordingly

--- a/fpga/pulpissimo-zedboard/rtl/pulp_clock_gating_xilinx.sv
+++ b/fpga/pulpissimo-zedboard/rtl/pulp_clock_gating_xilinx.sv
@@ -15,7 +15,13 @@ module pulp_clock_gating
    input  logic test_en_i,
    output logic clk_o
    );
+  logic         clk_en;
 
-   assign clk_o = clk_i;
-   
+  // Use a latch based clock gate instead of BUFGCE. Otherwise we quickly run out of BUFGCTRL cells on the FPGAs.
+  always_latch begin
+    if (clk_i == 1'b0) clk_en <= en_i | test_en_i;
+  end
+
+  assign clk_o = clk_i & clk_en;
+
 endmodule


### PR DESCRIPTION
- Add proper XDC constraints for all FPGA ports for all clock domain crossings
- Add a functional implementation of the functional clock gating cells in FPGA port
- Decrease default frequency on Zedboard to meet timing contraints with enabled FPU
- Add additional  Gitlab CI targets for all supported FPGA ports