### PR TITLE
Override new Zfinx parameter of pulp_soc

### DIFF
--- a/rtl/pulpissimo/soc_domain.sv
+++ b/rtl/pulpissimo/soc_domain.sv
@@ -265,7 +265,8 @@ module soc_domain #(
       .N_UART                           ( N_UART             ),
       .N_SPI                            ( N_SPI              ),
       .N_I2C                            ( N_I2C              ),
-      .ISOLATE_CLUSTER_CDC              ( 1                  )
+      .ISOLATE_CLUSTER_CDC              ( 1                  ),
+      .USE_ZFINX                        ( 0                  )
     ) pulp_soc_i (
         // Outputs
         .boot_l2_i                   (1'b0),


### PR DESCRIPTION
A recent change to pulp_soc (https://github.com/pulp-platform/pulp_soc/commit/f58645dca3cbb03a9fe1146c81cac53fb000bf5e) changed the default parameter of the Zfinx feature parameter of the RI5CY core. This commit overrides this new parameter to remain compatible with PULPissimos software infrastructure that assumes the presence of dedicated Floating Point registers. 