### PR TITLE
corrected ack seq

### DIFF
--- a/fpga/pulpissimo-genesys2/rtl/fpga_clk_gen.sv
+++ b/fpga/pulpissimo-genesys2/rtl/fpga_clk_gen.sv
@@ -65,10 +65,25 @@ module fpga_clk_gen (
   assign soc_cfg_lock_o = s_locked;
   assign per_cfg_lock_o = s_locked;
 
-  assign soc_cfg_ack_o = 1'b1; //Always acknowledge without doing anything for now
-  assign per_cfg_ack_o = 1'b1;
+  // assign soc_cfg_ack_o = 1'b1; //Always acknowledge without doing anything for now
+  // assign per_cfg_ack_o = 1'b1;
 
-  assign soc_cfg_r_data_o = 32'hdeadda7a;
+  always_comb begin
+    soc_cfg_ack_o       = 1'b0;
+    per_cfg_ack_o       = 1'b0;
+    cluster_cfg_ack_o   = 1'b0;
+    if (soc_cfg_req_i) begin
+      soc_cfg_ack_o = 1'b1;
+    end
+    if (per_cfg_req_i) begin
+      per_cfg_ack_o = 1'b1;
+    end
+    if (cluster_cfg_req_i) begin
+      cluster_cfg_ack_o = 1'b1;
+    end
+  end
+
+  assign soc_cfg_r_data_o = (soc_cfg_add_i == 2'b00 ? 32'hbeef0001 : (soc_cfg_add_i == 2'b01 ? 32'hbeef0003 : (soc_cfg_add_i == 2'b00 ? 32'hbeef0005 : 32'hbeef0007)));
   assign per_cfg_r_data_o = 32'hdeadda7a;
 
 endmodule : fpga_clk_gen

--- a/fpga/pulpissimo-nexys/rtl/fpga_clk_gen.sv
+++ b/fpga/pulpissimo-nexys/rtl/fpga_clk_gen.sv
@@ -65,10 +65,25 @@ module fpga_clk_gen (
   assign soc_cfg_lock_o = s_locked;
   assign per_cfg_lock_o = s_locked;
 
-  assign soc_cfg_ack_o = 1'b1; //Always acknowledge without doing anything for now
-  assign per_cfg_ack_o = 1'b1;
+  // assign soc_cfg_ack_o = 1'b1; //Always acknowledge without doing anything for now
+  // assign per_cfg_ack_o = 1'b1;
 
-  assign soc_cfg_r_data_o = 32'hdeadda7a;
+  always_comb begin
+    soc_cfg_ack_o       = 1'b0;
+    per_cfg_ack_o       = 1'b0;
+    cluster_cfg_ack_o   = 1'b0;
+    if (soc_cfg_req_i) begin
+      soc_cfg_ack_o = 1'b1;
+    end
+    if (per_cfg_req_i) begin
+      per_cfg_ack_o = 1'b1;
+    end
+    if (cluster_cfg_req_i) begin
+      cluster_cfg_ack_o = 1'b1;
+    end
+  end
+
+  assign soc_cfg_r_data_o = (soc_cfg_add_i == 2'b00 ? 32'hbeef0001 : (soc_cfg_add_i == 2'b01 ? 32'hbeef0003 : (soc_cfg_add_i == 2'b00 ? 32'hbeef0005 : 32'hbeef0007)));
   assign per_cfg_r_data_o = 32'hdeadda7a;
 
 endmodule : fpga_clk_gen

--- a/fpga/pulpissimo-nexys_video/rtl/fpga_clk_gen.sv
+++ b/fpga/pulpissimo-nexys_video/rtl/fpga_clk_gen.sv
@@ -65,10 +65,25 @@ module fpga_clk_gen (
   assign soc_cfg_lock_o = s_locked;
   assign per_cfg_lock_o = s_locked;
 
-  assign soc_cfg_ack_o = 1'b1; //Always acknowledge without doing anything for now
-  assign per_cfg_ack_o = 1'b1;
+  // assign soc_cfg_ack_o = 1'b1; //Always acknowledge without doing anything for now
+  // assign per_cfg_ack_o = 1'b1;
 
-  assign soc_cfg_r_data_o = 32'hdeadda7a;
+  always_comb begin
+    soc_cfg_ack_o       = 1'b0;
+    per_cfg_ack_o       = 1'b0;
+    cluster_cfg_ack_o   = 1'b0;
+    if (soc_cfg_req_i) begin
+      soc_cfg_ack_o = 1'b1;
+    end
+    if (per_cfg_req_i) begin
+      per_cfg_ack_o = 1'b1;
+    end
+    if (cluster_cfg_req_i) begin
+      cluster_cfg_ack_o = 1'b1;
+    end
+  end
+
+  assign soc_cfg_r_data_o = (soc_cfg_add_i == 2'b00 ? 32'hbeef0001 : (soc_cfg_add_i == 2'b01 ? 32'hbeef0003 : (soc_cfg_add_i == 2'b00 ? 32'hbeef0005 : 32'hbeef0007)));
   assign per_cfg_r_data_o = 32'hdeadda7a;
 
 endmodule : fpga_clk_gen

--- a/fpga/pulpissimo-zcu102/rtl/fpga_clk_gen.sv
+++ b/fpga/pulpissimo-zcu102/rtl/fpga_clk_gen.sv
@@ -65,10 +65,25 @@ module fpga_clk_gen (
   assign soc_cfg_lock_o = s_locked;
   assign per_cfg_lock_o = s_locked;
 
-  assign soc_cfg_ack_o = 1'b1; //Always acknowledge without doing anything for now
-  assign per_cfg_ack_o = 1'b1;
+  // assign soc_cfg_ack_o = 1'b1; //Always acknowledge without doing anything for now
+  // assign per_cfg_ack_o = 1'b1;
 
-  assign soc_cfg_r_data_o = 32'hdeadda7a;
+  always_comb begin
+    soc_cfg_ack_o       = 1'b0;
+    per_cfg_ack_o       = 1'b0;
+    cluster_cfg_ack_o   = 1'b0;
+    if (soc_cfg_req_i) begin
+      soc_cfg_ack_o = 1'b1;
+    end
+    if (per_cfg_req_i) begin
+      per_cfg_ack_o = 1'b1;
+    end
+    if (cluster_cfg_req_i) begin
+      cluster_cfg_ack_o = 1'b1;
+    end
+  end
+
+  assign soc_cfg_r_data_o = (soc_cfg_add_i == 2'b00 ? 32'hbeef0001 : (soc_cfg_add_i == 2'b01 ? 32'hbeef0003 : (soc_cfg_add_i == 2'b00 ? 32'hbeef0005 : 32'hbeef0007)));
   assign per_cfg_r_data_o = 32'hdeadda7a;
 
 endmodule : fpga_clk_gen

--- a/fpga/pulpissimo-zcu104/rtl/fpga_clk_gen.sv
+++ b/fpga/pulpissimo-zcu104/rtl/fpga_clk_gen.sv
@@ -65,10 +65,25 @@ module fpga_clk_gen (
   assign soc_cfg_lock_o = s_locked;
   assign per_cfg_lock_o = s_locked;
 
-  assign soc_cfg_ack_o = 1'b1; //Always acknowledge without doing anything for now
-  assign per_cfg_ack_o = 1'b1;
+  // assign soc_cfg_ack_o = 1'b1; //Always acknowledge without doing anything for now
+  // assign per_cfg_ack_o = 1'b1;
 
-  assign soc_cfg_r_data_o = 32'hdeadda7a;
+  always_comb begin
+    soc_cfg_ack_o       = 1'b0;
+    per_cfg_ack_o       = 1'b0;
+    cluster_cfg_ack_o   = 1'b0;
+    if (soc_cfg_req_i) begin
+      soc_cfg_ack_o = 1'b1;
+    end
+    if (per_cfg_req_i) begin
+      per_cfg_ack_o = 1'b1;
+    end
+    if (cluster_cfg_req_i) begin
+      cluster_cfg_ack_o = 1'b1;
+    end
+  end
+
+  assign soc_cfg_r_data_o = (soc_cfg_add_i == 2'b00 ? 32'hbeef0001 : (soc_cfg_add_i == 2'b01 ? 32'hbeef0003 : (soc_cfg_add_i == 2'b00 ? 32'hbeef0005 : 32'hbeef0007)));
   assign per_cfg_r_data_o = 32'hdeadda7a;
 
 endmodule : fpga_clk_gen

--- a/fpga/pulpissimo-zedboard/rtl/fpga_clk_gen.sv
+++ b/fpga/pulpissimo-zedboard/rtl/fpga_clk_gen.sv
@@ -65,10 +65,25 @@ module fpga_clk_gen (
   assign soc_cfg_lock_o = s_locked;
   assign per_cfg_lock_o = s_locked;
 
-  assign soc_cfg_ack_o = 1'b1; //Always acknowledge without doing anything for now
-  assign per_cfg_ack_o = 1'b1;
+  // assign soc_cfg_ack_o = 1'b1; //Always acknowledge without doing anything for now
+  // assign per_cfg_ack_o = 1'b1;
 
-  assign soc_cfg_r_data_o = 32'hdeadda7a;
+  always_comb begin
+    soc_cfg_ack_o       = 1'b0;
+    per_cfg_ack_o       = 1'b0;
+    cluster_cfg_ack_o   = 1'b0;
+    if (soc_cfg_req_i) begin
+      soc_cfg_ack_o = 1'b1;
+    end
+    if (per_cfg_req_i) begin
+      per_cfg_ack_o = 1'b1;
+    end
+    if (cluster_cfg_req_i) begin
+      cluster_cfg_ack_o = 1'b1;
+    end
+  end
+
+  assign soc_cfg_r_data_o = (soc_cfg_add_i == 2'b00 ? 32'hbeef0001 : (soc_cfg_add_i == 2'b01 ? 32'hbeef0003 : (soc_cfg_add_i == 2'b00 ? 32'hbeef0005 : 32'hbeef0007)));
   assign per_cfg_r_data_o = 32'hdeadda7a;
 
 endmodule : fpga_clk_gen


### PR DESCRIPTION
From #203
>pulp-freertos was hanging when accessing the dummy FLLs. apb_fll_if expects a 4 cycle handshake: assert req, assert ack, >deassert req, deassert ack. The dummy (FPGA) FLL simply asserted ack all the time, which means the state machine hung in >phase 2.

>I have tested the fix on nexysA7-100T. The RTL looks identical on all of the platforms (might be preferable to have a Xilinx >directory that all Xilinx boards referred to) so I replaced all of them. The test consists of using gdb to observe that multiple reads >of the FLL registers don't hang. The actual application, hello_world_pmsis, does not function correctly which suggests there is >some other issue to be resolved.
