### PR TITLE
Fix bender build & execution errors, align ips_list to bender

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -78,4 +78,4 @@ sources:
     defines:
       SPEEDSIM: ~
     files:
-      - rtl/vip/spi_flash/S25fs256s/model/s25fs256s.v  
+      - rtl/vip/spi_flash/S25fs256s/model/s25fs256s.v

--- a/sim/tcl_files/config/vsim.tcl
+++ b/sim/tcl_files/config/vsim.tcl
@@ -25,7 +25,9 @@ if {[info exists ::env(VSIM_RUNNER_FLAGS)]} {
 quietly set VSIM_TB_PATH $VSIM_SCRIPTS_PATH/../tb
 #######################################
 #######################################
-quietly source $VSIM_SCRIPTS_PATH/tcl_files/config/vsim_ips.tcl
+if {[info exists ::env(BENDER)]} {} {
+    quietly source $VSIM_SCRIPTS_PATH/tcl_files/config/vsim_ips.tcl
+}
 
 quietly source $VSIM_SCRIPTS_PATH/tcl_files/config/vsim_sdvt.tcl
 quietly source $VSIM_SCRIPTS_PATH/tcl_files/config/vsim_custom.tcl


### PR DESCRIPTION
When cloning this from scratch and building with bender, I encountered a few minor issues building and running code, fixed here.

Also, I forgot to align `ips_list.yml`, fixed here. There are version conflicts present when using IPApproX, as the `fpnew` dependency has an `ips_list.yml` calling an older version of `common_cells`, and `register_interface` has an `ips_list.yml` calling an older version of `axi` ([being fixed](https://github.com/pulp-platform/pulp_soc/pull/53)).