### PR TITLE
tb: Fix SimJTAG instantiation

### DIFF
--- a/rtl/tb/SimJTAG.sv
+++ b/rtl/tb/SimJTAG.sv
@@ -2,6 +2,7 @@
 //VCS coverage exclude_file
 import "DPI-C" function int jtag_tick
 (
+ input int port,
  output bit jtag_TCK,
  output bit jtag_TMS,
  output bit jtag_TDI,
@@ -11,7 +12,8 @@ import "DPI-C" function int jtag_tick
 );
 
 module SimJTAG #(
-                 parameter TICK_DELAY = 50
+                 parameter TICK_DELAY = 50,
+                 parameter PORT = 0
                  )(
 
                    input         clock,
@@ -69,7 +71,7 @@ module SimJTAG #(
          if (enable && init_done_sticky) begin
             tickCounterReg <= tickCounterNxt;
             if (tickCounterReg == 0) begin
-               __exit = jtag_tick(
+               __exit = jtag_tick(PORT,
                                   __jtag_TCK,
                                   __jtag_TMS,
                                   __jtag_TDI,

--- a/rtl/tb/remote_bitbang/sim_jtag.c
+++ b/rtl/tb/remote_bitbang/sim_jtag.c
@@ -13,8 +13,10 @@ int jtag_tick(int port, unsigned char *jtag_TCK, unsigned char *jtag_TMS,
 
 {
     if (!init) {
-	if (port < 0 || port > UINT16_MAX)
-	    fprintf(stderr, "Port number of out range: %d\n", port);
+	if (port < 0 || port > UINT16_MAX) {
+	    fprintf(stderr, "remote_bitbang: port number of out range: %d\n", port);
+	    abort();
+	}
         init = rbs_init(port);
     }
 

--- a/rtl/tb/tb_pulp.sv
+++ b/rtl/tb/tb_pulp.sv
@@ -516,9 +516,9 @@ module tb_pulp;
 
     // jtag calls from dpi
     SimJTAG #(
-        .TICK_DELAY (1)
-    )
-    i_sim_jtag (
+        .TICK_DELAY (1),
+        .PORT       (4567)
+    ) i_sim_jtag (
         .clock                ( w_clk_ref            ),
         .reset                ( ~s_rst_n             ),
         .enable               ( sim_jtag_enable      ),


### PR DESCRIPTION
* Needs a PORT parameter
* sim_jtag.c should abort when provided bad arguments