### PR TITLE
Fix Bender file list

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -48,8 +48,6 @@ sources:
       - rtl/tb/pulp_tap_pkg.sv
       - rtl/tb/tb_clk_gen.sv
       - rtl/tb/tb_fs_handler.sv
-      - rtl/tb/dpi_models/dpi_models.sv
-      - rtl/tb/tb_driver/tb_driver.sv
       - rtl/tb/tb_pulp.sv
       - rtl/tb/SimJTAG.sv
       - rtl/tb/SimDTM.sv


### PR DESCRIPTION
Removed two files in the Bender file list since they are symlinks to the IPApprox ips directory. They should already be compiled as part of the tbtools dependency specification in Bender.yml. 