### PR TITLE
tb: Reverse FAST_DEBUG_PRELOAD not driving bootsel

### DIFF
--- a/rtl/tb/tb_pulp.sv
+++ b/rtl/tb/tb_pulp.sv
@@ -667,6 +667,10 @@ module tb_pulp;
 
             end else if (LOAD_L2 == "JTAG") begin
                s_bootsel = 1'b1;
+            end else if (LOAD_L2 == "FAST_DEBUG_PRELOAD") begin
+               s_bootsel = 1'b1;
+            end else begin
+               $error("Unknown L2 loadmode: %s", LOAD_L2);
             end
 
             if (LOAD_L2 == "JTAG" || LOAD_L2 == "FAST_DEBUG_PRELOAD") begin


### PR DESCRIPTION
Weirdly enough it works withouth this change, so it went through testing. Reverse it anyway.