### PR TITLE
Fixed linkage in remote_bitbang library

### DIFF
--- a/rtl/tb/remote_bitbang/remote_bitbang.c
+++ b/rtl/tb/remote_bitbang/remote_bitbang.c
@@ -13,6 +13,22 @@
 
 #include "remote_bitbang.h"
 
+int rbs_err;
+
+unsigned char tck;
+unsigned char tms;
+unsigned char tdi;
+unsigned char trstn;
+unsigned char tdo;
+unsigned char quit;
+
+int socket_fd;
+int client_fd;
+
+const ssize_t buf_size = 64 * 1024;
+char recv_buf[64 * 1024];
+ssize_t recv_start, recv_end;
+
 int rbs_init(uint16_t port)
 {
     socket_fd  = 0;

--- a/rtl/tb/remote_bitbang/remote_bitbang.h
+++ b/rtl/tb/remote_bitbang/remote_bitbang.h
@@ -8,21 +8,21 @@
 
 #define VERBOSE 0
 
-int rbs_err;
+extern int rbs_err;
 
-unsigned char tck;
-unsigned char tms;
-unsigned char tdi;
-unsigned char trstn;
-unsigned char tdo;
-unsigned char quit;
+extern unsigned char tck;
+extern unsigned char tms;
+extern unsigned char tdi;
+extern unsigned char trstn;
+extern unsigned char tdo;
+extern unsigned char quit;
 
-int socket_fd;
-int client_fd;
+extern int socket_fd;
+extern int client_fd;
 
-static const ssize_t buf_size = 64 * 1024;
-char recv_buf[64 * 1024];
-ssize_t recv_start, recv_end;
+extern const ssize_t buf_size;
+extern char recv_buf[];
+extern ssize_t recv_start, recv_end;
 
 // Create a new server, listening for connections from localhost on the given
 // port.


### PR DESCRIPTION
This pull request fixes the linking of the bitbang library under modern GCC version where the multiple definitions of the global state results in the following error:

```bash
#> gcc (Gentoo Hardened 10.3.0 p1) 10.3.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

#> make all
cc -MT remote_bitbang.o -MMD -MP -MF ./.d/remote_bitbang.Td -std=gnu11 -fno-strict-aliasing -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-function -Wno-missing-braces -O2 -g -march=native -DENABLE_LOGGING -DNDEBUG -fPIC -I./  \
        -c  remote_bitbang.c -o remote_bitbang.o                                                                                                                                              cc -MT sim_jtag.o -MMD -MP -MF ./.d/sim_jtag.Td -std=gnu11 -fno-strict-aliasing -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-function -Wno-missing-braces -O2 -g -march=native -DENABLE_LOGGING -DNDEBUG -fPIC -I./  \
        -c  sim_jtag.c -o sim_jtag.o
ld -shared -E --exclude-libs ALL -o librbs.so  \
        remote_bitbang.o sim_jtag.o
ld: sim_jtag.o:/root/uni/various/pulpissimo/pulpissimo/rtl/tb/remote_bitbang/remote_bitbang.h:25: multiple definition of `recv_end'; remote_bitbang.o:/root/uni/various/pulpissimo/pulpissimo/rtl/tb/remote_bitbang/remote_bitbang.h:25: first defined here
ld: sim_jtag.o:/root/uni/various/pulpissimo/pulpissimo/rtl/tb/remote_bitbang/remote_bitbang.h:25: multiple definition of `recv_start'; remote_bitbang.o:/root/uni/various/pulpissimo/pulpissimo/rtl/tb/remote_bitbang/remote_bitbang.h:25: first defined here
ld: sim_jtag.o:/root/uni/various/pulpissimo/pulpissimo/rtl/tb/remote_bitbang/remote_bitbang.h:24: multiple definition of `recv_buf'; remote_bitbang.o:/root/uni/various/pulpissimo/pulpissimo/rtl/tb/remote_bitbang/remote_bitbang.h:24: first defined here
ld: sim_jtag.o:/root/uni/various/pulpissimo/pulpissimo/rtl/tb/remote_bitbang/remote_bitbang.h:21: multiple definition of `client_fd'; remote_bitbang.o:/root/uni/various/pulpissimo/pulpissimo/rtl/tb/remote_bitbang/remote_bitbang.h:21: first defined here
ld: sim_jtag.o:/root/uni/various/pulpissimo/pulpissimo/rtl/tb/remote_bitbang/remote_bitbang.h:20: multiple definition of `socket_fd'; remote_bitbang.o:/root/uni/various/pulpissimo/pulpissimo/rtl/tb/remote_bitbang/remote_bitbang.h:20: first defined here
ld: sim_jtag.o:/root/uni/various/pulpissimo/pulpissimo/rtl/tb/remote_bitbang/remote_bitbang.h:18: multiple definition of `quit'; remote_bitbang.o:/root/uni/various/pulpissimo/pulpissimo/rtl/tb/remote_bitbang/remote_bitbang.h:18: first defined here
ld: sim_jtag.o:/root/uni/various/pulpissimo/pulpissimo/rtl/tb/remote_bitbang/remote_bitbang.h:17: multiple definition of `tdo'; remote_bitbang.o:/root/uni/various/pulpissimo/pulpissimo/rtl/tb/remote_bitbang/remote_bitbang.h:17: first defined here
ld: sim_jtag.o:/root/uni/various/pulpissimo/pulpissimo/rtl/tb/remote_bitbang/remote_bitbang.h:16: multiple definition of `trstn'; remote_bitbang.o:/root/uni/various/pulpissimo/pulpissimo/rtl/tb/remote_bitbang/remote_bitbang.h:16: first defined here
ld: sim_jtag.o:/root/uni/various/pulpissimo/pulpissimo/rtl/tb/remote_bitbang/remote_bitbang.h:15: multiple definition of `tdi'; remote_bitbang.o:/root/uni/various/pulpissimo/pulpissimo/rtl/tb/remote_bitbang/remote_bitbang.h:15: first defined here
ld: sim_jtag.o:/root/uni/various/pulpissimo/pulpissimo/rtl/tb/remote_bitbang/remote_bitbang.h:14: multiple definition of `tms'; remote_bitbang.o:/root/uni/various/pulpissimo/pulpissimo/rtl/tb/remote_bitbang/remote_bitbang.h:14: first defined here
ld: sim_jtag.o:/root/uni/various/pulpissimo/pulpissimo/rtl/tb/remote_bitbang/remote_bitbang.h:13: multiple definition of `tck'; remote_bitbang.o:/root/uni/various/pulpissimo/pulpissimo/rtl/tb/remote_bitbang/remote_bitbang.h:13: first defined here
ld: sim_jtag.o:/root/uni/various/pulpissimo/pulpissimo/rtl/tb/remote_bitbang/remote_bitbang.h:11: multiple definition of `rbs_err'; remote_bitbang.o:/root/uni/various/pulpissimo/pulpissimo/rtl/tb/remote_bitbang/remote_bitbang.h:11: first defined here
make: *** [Makefile:87: librbs.so] Error 1
```

With GCC 9.3.0 the linker ignores the multiple definitions:
```
#> gcc-9.3.0 --version
gcc-9.3.0 (Gentoo Hardened 9.3.0-r2 p4) 9.3.0
Copyright (C) 2019 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

#> CC=gcc-9.3.0 make all
gcc-9.3.0 -MT remote_bitbang.o -MMD -MP -MF ./.d/remote_bitbang.Td -std=gnu11 -fno-strict-aliasing -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-function -Wno-missing-braces -O2 -g -march=native -DENABLE_LOGGING -DNDEBUG -fPIC -I./  \
        -c  remote_bitbang.c -o remote_bitbang.o
gcc-9.3.0 -MT sim_jtag.o -MMD -MP -MF ./.d/sim_jtag.Td -std=gnu11 -fno-strict-aliasing -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-function -Wno-missing-braces -O2 -g -march=native -DENABLE_LOGGING -DNDEBUG -fPIC -I./  \
        -c  sim_jtag.c -o sim_jtag.o
ld -shared -E --exclude-libs ALL -o librbs.so  \
        remote_bitbang.o sim_jtag.o
```
