### PR TITLE
Bump bender

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -15,7 +15,7 @@ package:
 dependencies:
   common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.21.0 }
   jtag_pulp: { git: "https://github.com/pulp-platform/jtag_pulp.git", rev: "v0.1" }
-  pulp_soc: { git: "https://github.com/pulp-platform/pulp_soc.git", version: 3.1.0 }
+  pulp_soc: { git: "https://github.com/pulp-platform/pulp_soc.git", version: 3.2.0 }
   tbtools: { git: "https://github.com/pulp-platform/tbtools.git", version: 0.2.1 }
   tech_cells_generic: { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.3 }
 

--- a/Bender.yml
+++ b/Bender.yml
@@ -13,8 +13,11 @@ package:
     - "Luca Valente <luca.valente2@unibo.it>"
 
 dependencies:
+  common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.21.0 }
+  jtag_pulp: { git: "https://github.com/pulp-platform/jtag_pulp.git", rev: "v0.1" }
   pulp_soc: { git: "https://github.com/pulp-platform/pulp_soc.git", version: 3.1.0 }
   tbtools: { git: "https://github.com/pulp-platform/tbtools.git", version: 0.2.1 }
+  tech_cells_generic: { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.3 }
 
 workspace:
   # package_links:

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ INSTALL_FILES += $(shell cd sim && find fs -type f)
 
 $(foreach file, $(INSTALL_FILES), $(eval $(call declareInstallFile,$(file))))
 
-VLOG_ARGS += -suppress 2583 -suppress 13314
+VLOG_ARGS += -suppress 2583 -suppress 13314 \"+incdir+\$$ROOT/rtl/includes\"
 BENDER_SIM_BUILD_DIR = sim
 BENDER_FPGA_SCRIPTS_DIR = fpga/pulpissimo/tcl/generated
 
@@ -247,8 +247,8 @@ lint:
 # Bender integration
 bender:
 ifeq (,$(wildcard ./bender))
-	curl --proto '=https' --tlsv1.2 -sSf https://fabianschuiki.github.io/bender/init \
-		| bash -s -- 0.23.2
+	curl --proto '=https' --tlsv1.2 -sSf https://pulp-platform.github.io/bender/init \
+		| bash -s -- 0.24.0
 	touch bender
 endif
 


### PR DESCRIPTION
- Update bender to v0.24.0 to incorporate new bender features - requires fix due to changed `export_include_dir` handling
- Bump `pulp_soc` to v3.2.0 to fix #313 and use only https links (no git@ links requiring an uploaded ssh key)