### PR TITLE
fix sim_jtag for verilator

### DIFF
--- a/rtl/tb/remote_bitbang/sim_jtag.c
+++ b/rtl/tb/remote_bitbang/sim_jtag.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include "remote_bitbang.h"
+#include "sim_jtag.h"
 
 int init = 0;
 

--- a/rtl/tb/remote_bitbang/sim_jtag.h
+++ b/rtl/tb/remote_bitbang/sim_jtag.h
@@ -1,0 +1,22 @@
+// Copyright 2021 OpenHW Group
+// Solderpad Hardware License, Version 2.1, see LICENSE.md for details.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+
+#ifndef PULP_PLATFORM_SIMJTAG_H_
+#define PULP_PLATFORM_SIMJTAG_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+
+int jtag_tick(int port, unsigned char *jtag_TCK, unsigned char *jtag_TMS,
+              unsigned char *jtag_TDI, unsigned char *jtag_TRSTn,
+              unsigned char jtag_TDO);
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // PULP_PLATFORM_SIMJTAG_H_


### PR DESCRIPTION
When compiling for Verilator, you need to have the functions defined in the header file otherwise the function is not found at link time