### PR TITLE
Fix: fix tdo io direction from input to inout

### DIFF
--- a/target/fpga/pulpissimo-nexys/rtl/xilinx_pulpissimo.v
+++ b/target/fpga/pulpissimo-nexys/rtl/xilinx_pulpissimo.v
@@ -70,7 +70,7 @@ module xilinx_pulpissimo (
 
   inout wire  pad_jtag_tck,
   inout wire  pad_jtag_tdi,
-  input wire  pad_jtag_tdo,
+  inout wire  pad_jtag_tdo,
   inout wire  pad_jtag_tms
   //input wire  pad_jtag_trst
  );


### PR DESCRIPTION
**PR Description**
**Summary**
This PR fixes a bug in the nexys FPGA top-level wrapper (xilinx_pulpissimo.v) where the pad_jtag_tdo port was incorrectly declared as an input. This prevented the JTAG interface from outputting data, making debugging impossible on nexys FPGA targets.

**Changes**
Modified ./target/fpga/pulpissimo-nexys/rtl/xilinx_pulpissimo.v.
Changed the direction of pad_jtag_tdo from input to inout.

**Reasoning**
In the JTAG standard, TDO is the serial output stream from the chip. Declaring it as an input in the top-level module prevents the internal JTAG controller from driving the external pin.

**Verification**
Tested on Nexys A7 100T. After this change, the JTAG IDCODE can be correctly scanned by OpenOCD and OpenOCD/GDB works properly.